### PR TITLE
Fix table crash on fractional int coordinates: truncate at point of use

### DIFF
--- a/src/namespaces/table/TableHelper.ts
+++ b/src/namespaces/table/TableHelper.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { Series } from '../../Series';
-import { TableObject } from './TableObject';
+import { TableObject, truncCoord } from './TableObject';
 import { silentInSecondary } from '../silentInSecondary';
 
 export class TableHelper {
@@ -248,10 +248,10 @@ export class TableHelper {
         const tbl = this._resolve(table_id) as TableObject;
         if (!tbl || tbl._deleted) return;
 
-        const sc = this._resolve(start_column) ?? 0;
-        const sr = this._resolve(start_row) ?? 0;
-        const ec = this._resolve(end_column) ?? sc;
-        const er = this._resolve(end_row) ?? sr;
+        const sc = truncCoord(this._resolve(start_column) ?? 0);
+        const sr = truncCoord(this._resolve(start_row) ?? 0);
+        const ec = truncCoord(this._resolve(end_column) ?? sc);
+        const er = truncCoord(this._resolve(end_row) ?? sr);
 
         for (let r = sr; r <= er; r++) {
             for (let c = sc; c <= ec; c++) {
@@ -292,10 +292,13 @@ export class TableHelper {
         const tbl = this._resolve(table_id) as TableObject;
         if (!tbl || tbl._deleted) return;
 
-        const sc = this._resolve(start_column) ?? 0;
-        const sr = this._resolve(start_row) ?? 0;
-        const ec = this._resolve(end_column) ?? 0;
-        const er = this._resolve(end_row) ?? 0;
+        const sc = truncCoord(this._resolve(start_column) ?? 0);
+        const sr = truncCoord(this._resolve(start_row) ?? 0);
+        const ec = truncCoord(this._resolve(end_column) ?? 0);
+        const er = truncCoord(this._resolve(end_row) ?? 0);
+
+        // na coordinates: silent no-op (matches the cell-access behavior).
+        if (isNaN(sc) || isNaN(sr) || isNaN(ec) || isNaN(er)) return;
 
         // Mark all cells in the region as merged, pointing to the start cell
         for (let r = sr; r <= er; r++) {

--- a/src/namespaces/table/TableObject.ts
+++ b/src/namespaces/table/TableObject.ts
@@ -6,6 +6,17 @@ export function resetTableIdCounter() {
     _tableIdCounter = 0;
 }
 
+/**
+ * Pine truncates fractional "int" values at the point of use: since v6,
+ * `int / int` keeps the static type `int` but can carry a fractional value
+ * (e.g. `(i / 6) + 1` with a loop counter), and TradingView truncates it
+ * toward zero when it is consumed as a table coordinate. NaN (Pine `na`)
+ * stays NaN so the bounds checks below reject it as a silent no-op.
+ */
+export function truncCoord(v: number): number {
+    return Number.isFinite(v) ? Math.trunc(v) : NaN;
+}
+
 export interface TableCell {
     text: string;
     width: number;
@@ -57,8 +68,8 @@ export class TableObject {
     ) {
         this.id = _tableIdCounter++;
         this.position = position;
-        this.columns = columns;
-        this.rows = rows;
+        this.columns = truncCoord(columns);
+        this.rows = truncCoord(rows);
         this.bgcolor = bgcolor;
         this.frame_color = frame_color;
         this.frame_width = frame_width;
@@ -70,9 +81,9 @@ export class TableObject {
 
         // Initialize cells grid (rows × columns) with nulls
         this.cells = [];
-        for (let r = 0; r < rows; r++) {
+        for (let r = 0; r < this.rows; r++) {
             this.cells[r] = [];
-            for (let c = 0; c < columns; c++) {
+            for (let c = 0; c < this.columns; c++) {
                 this.cells[r][c] = null;
             }
         }
@@ -105,7 +116,9 @@ export class TableObject {
     }
 
     setCell(column: number, row: number, props: Partial<TableCell>): void {
-        if (row < 0 || row >= this.rows || column < 0 || column >= this.columns) return;
+        column = truncCoord(column);
+        row = truncCoord(row);
+        if (!(row >= 0 && row < this.rows && column >= 0 && column < this.columns)) return;
 
         const existing = this.cells[row][column];
         if (existing && existing._merged && existing._merge_parent) {
@@ -127,12 +140,16 @@ export class TableObject {
     }
 
     getCell(column: number, row: number): TableCell | null {
-        if (row < 0 || row >= this.rows || column < 0 || column >= this.columns) return null;
+        column = truncCoord(column);
+        row = truncCoord(row);
+        if (!(row >= 0 && row < this.rows && column >= 0 && column < this.columns)) return null;
         return this.cells[row][column];
     }
 
     clearCell(column: number, row: number): void {
-        if (row < 0 || row >= this.rows || column < 0 || column >= this.columns) return;
+        column = truncCoord(column);
+        row = truncCoord(row);
+        if (!(row >= 0 && row < this.rows && column >= 0 && column < this.columns)) return;
         this.cells[row][column] = null;
     }
 

--- a/tests/namespaces/table/table-fractional-int-coords.test.ts
+++ b/tests/namespaces/table/table-fractional-int-coords.test.ts
@@ -1,0 +1,108 @@
+import { PineTS } from 'index';
+import { describe, expect, it } from 'vitest';
+
+import { Provider } from '@pinets/marketData/Provider.class';
+
+/**
+ * Pine truncates fractional "int" values at the point of use.
+ *
+ * Since Pine v6, `int / int` never truncates (see TradingView's v6 migration
+ * guide, "Fractional division of constants") but the static TYPE of the result
+ * stays `int`, so expressions like `(i / 6) + 1` remain valid arguments for
+ * int-typed parameters such as table.cell()'s column/row. TradingView truncates
+ * the fractional value toward zero when it is consumed (same rule as the
+ * history-referencing offset and the int() cast).
+ *
+ * Regression: the "Ultimate Opening Range Breakout" variant with an hourly
+ * activity dashboard computes `row = (i / 6) + 1` and crashed PineTS with
+ * "Cannot read properties of undefined (reading '1')" because the fractional
+ * row slipped past TableObject.setCell's bounds check.
+ */
+describe('table: fractional int coordinates (point-of-use truncation)', () => {
+    function newPineTS() {
+        return new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date('2024-01-01').getTime(), new Date('2024-01-03').getTime());
+    }
+
+    it('v6 int-division row index: 24 hourly cells land on rows 1..4 (reported bug shape)', async () => {
+        const pineTS = newPineTS();
+        const { plots } = await pineTS.run(`
+//@version=6
+indicator("t")
+if barstate.islast
+    var table t = table.new(position.bottom_right, 6, 6)
+    for i = 0 to 23
+        t.cell(i % 6, (i / 6) + 1, str.tostring(i))
+plot(close)
+`);
+
+        const tables = plots['__tables__'].data[0].value;
+        expect(tables.length).toBe(1);
+        const cells = tables[0].cells;
+
+        // On TradingView, i = 0..5 -> row 1, 6..11 -> row 2, 12..17 -> row 3, 18..23 -> row 4.
+        for (let i = 0; i <= 23; i++) {
+            const row = Math.trunc(i / 6) + 1;
+            const col = i % 6;
+            expect(cells[row][col]?.text, `cell for i=${i}`).toBe(String(i));
+        }
+        // Row 0 and row 5 stay untouched.
+        expect(cells[0].every((c: any) => c === null)).toBe(true);
+        expect(cells[5].every((c: any) => c === null)).toBe(true);
+    });
+
+    it('truncates fractional coordinates toward zero in table.cell()', async () => {
+        const pineTS = newPineTS();
+        const { result } = await pineTS.run((context) => {
+            var t = table.new('top_right', 3, 3);
+            table.cell(t, 1.9, 2.9, 'X');
+            var cell = t.getCell(1, 2);
+            var cellText = cell ? cell.text : 'missing';
+            return { cellText };
+        });
+        expect(result.cellText[0]).toBe('X');
+    });
+
+    it('na/NaN coordinates are a silent no-op, not a crash', async () => {
+        const pineTS = newPineTS();
+        const { result } = await pineTS.run((context) => {
+            var t = table.new('top_right', 2, 2);
+            table.cell(t, NaN, NaN, 'X');
+            table.cell(t, 0, NaN, 'Y');
+            var cell = t.getCell(0, 0);
+            var untouched = cell === null;
+            return { untouched };
+        });
+        expect(result.untouched[0]).toBe(true);
+    });
+
+    it('truncates fractional coordinates in merge_cells and cell setters', async () => {
+        const pineTS = newPineTS();
+        const { result } = await pineTS.run((context) => {
+            var t = table.new('top_right', 4, 4);
+            table.cell(t, 0, 0, 'A');
+            table.merge_cells(t, 0.4, 0.4, 2.6, 0.9); // -> merge (0,0)..(2,0)
+            table.cell_set_text(t, 0.7, 0.2, 'B'); // -> (0,0)
+            var cell = t.getCell(0, 0);
+            var cellText = cell ? cell.text : 'missing';
+            var merge = t.merges[0];
+            var mergeEndCol = merge.endCol;
+            var mergeEndRow = merge.endRow;
+            return { cellText, mergeEndCol, mergeEndRow };
+        });
+        expect(result.cellText[0]).toBe('B');
+        expect(result.mergeEndCol[0]).toBe(2);
+        expect(result.mergeEndRow[0]).toBe(0);
+    });
+
+    it('truncates fractional dimensions in table.new()', async () => {
+        const pineTS = newPineTS();
+        const { result } = await pineTS.run((context) => {
+            var t = table.new('top_right', 3.7, 2.9);
+            var t_columns = t.columns;
+            var t_rows = t.rows;
+            return { t_columns, t_rows };
+        });
+        expect(result.t_columns[0]).toBe(3);
+        expect(result.t_rows[0]).toBe(2);
+    });
+});


### PR DESCRIPTION
## Summary

- Fixes the runtime crash `Cannot read properties of undefined (reading '1')` when a fractional-valued `int` (e.g. `(i / 6) + 1` under Pine v6 division semantics) is used as a `table.cell()` coordinate.
- Since v6, `int / int` never truncates (#284) but the static type stays `int`, so such expressions are valid coordinates on TradingView, which truncates the fractional value toward zero **at the point of use**. PineTS lacked that truncation: the fractional row passed `TableObject.setCell`'s bounds check (`1.1666 < 0` and `1.1666 >= rows` are both false) and `this.cells[1.1666][col]` threw.
- Fix: truncate coordinates at the point of use in `TableObject.setCell`/`getCell`/`clearCell` and the constructor's dimensions, and sanitize loop bounds in `TableHelper.clear()`/`merge_cells()`. `NaN` (`na`) coordinates are now a silent no-op instead of a crash.

Reported via an "Ultimate Opening Range Breakout" variant whose hourly activity dashboard computes `row = (i / 6) + 1` inside a `for i = 0 to 23` loop.

## Test plan

- [x] New regression suite `tests/namespaces/table/table-fractional-int-coords.test.ts` (5 tests), written first and failing with the original errors on the unfixed code:
  - v6 int-division row index (reported bug shape): 24 hourly cells land on rows 1..4
  - fractional coordinates truncate toward zero in `table.cell()`
  - `na`/`NaN` coordinates are a silent no-op
  - fractional coordinates in `merge_cells` and `cell_set_*`
  - fractional dimensions in `table.new()`
- [x] Full reporting script (both dashboards) runs end to end: hit-rate table 4x13 with 34 filled cells, hourly activity table 6x6 with all 24 hour cells on rows 1..4.
- [x] Full suite green: 165 test files passed (3 skipped), 1811 tests passed, 0 failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized table coordinate handling and parity fix with documented tests; no auth, data, or cross-cutting runtime changes.
> 
> **Overview**
> Fixes a runtime crash when Pine v6 **fractional `int`** values (e.g. `(i / 6) + 1`) are passed as table row/column indices. PineTS previously let those values pass bounds checks and index `cells` with non-integer keys; it now matches TradingView by **truncating toward zero at use** via a shared `truncCoord` helper.
> 
> **`truncCoord`** is applied to `table.new` dimensions and to `setCell` / `getCell` / `clearCell`, plus range bounds in `table.clear` and `table.merge_cells`. **`na` / NaN** coordinates are rejected as a **silent no-op** (including an explicit early return in `merge_cells`). A new regression suite covers the reported hourly-dashboard loop, fractional `table.cell`, merge/setter paths, and fractional `table.new` sizes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b16623d6097ef778362cd995e0152051109b7b42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->