### PR TITLE
Fix table.* named-arg detection dropping force_overlay, frame_width, border_width

### DIFF
--- a/src/namespaces/table/TableHelper.ts
+++ b/src/namespaces/table/TableHelper.ts
@@ -4,6 +4,33 @@ import { Series } from '../../Series';
 import { TableObject } from './TableObject';
 import { silentInSecondary } from '../silentInSecondary';
 
+// Complete named-parameter lists for named-args detection. These MUST cover
+// every parameter of the corresponding Pine function: if a key is missing, a
+// call naming ONLY missing keys (e.g. `table.new(..., force_overlay=true)`)
+// falls through to positional handling — the options object lands in the next
+// positional slot and its values are silently dropped.
+//prettier-ignore
+const TABLE_NEW_PARAMS = [
+    'position', 'columns', 'rows', 'bgcolor', 'frame_color', 'frame_width',
+    'border_color', 'border_width', 'force_overlay',
+];
+//prettier-ignore
+const TABLE_CELL_PARAMS = [
+    'column', 'row', 'text', 'width', 'height', 'text_color', 'text_halign',
+    'text_valign', 'text_size', 'bgcolor', 'tooltip', 'text_font_family',
+];
+const TABLE_RANGE_PARAMS = ['start_column', 'start_row', 'end_column', 'end_row'];
+
+// Detect the transpiler's trailing named-args object: a plain {key: val} bag
+// carrying at least one known parameter name. TableObject is excluded because
+// it shares property names with table.new params (bgcolor, position, ...) and
+// can legitimately appear as a trailing positional arg (e.g. `table.clear(t)`).
+function isNamedArgs(arg: any, params: string[]): boolean {
+    return !!arg && typeof arg === 'object' && !Array.isArray(arg)
+        && !(arg instanceof TableObject)
+        && params.some((p) => p in arg);
+}
+
 export class TableHelper {
     private _tables: TableObject[] = [];
 
@@ -68,9 +95,7 @@ export class TableHelper {
         // e.g. table.new("top_right", 3, 3, {bgcolor: "#1e293b", frame_color: "#475569", ...})
         // or   table.new({position: "top_right", columns: 3, rows: 3, bgcolor: "#1e293b", ...})
         const lastArg = args[args.length - 1];
-        const hasOpts = lastArg && typeof lastArg === 'object' && !Array.isArray(lastArg)
-            && ('bgcolor' in lastArg || 'frame_color' in lastArg || 'border_color' in lastArg
-                || 'position' in lastArg || 'columns' in lastArg || 'rows' in lastArg);
+        const hasOpts = isNamedArgs(lastArg, TABLE_NEW_PARAMS);
 
         if (hasOpts) {
             const opts = lastArg;
@@ -148,12 +173,7 @@ export class TableHelper {
         // Detect trailing options object from transpiler's named-args pattern
         // e.g. table.cell(t1, 0, 0, {text: "X", text_color: "#fff", ...})
         const lastArg = args[args.length - 1];
-        const hasOpts = lastArg && typeof lastArg === 'object' && !Array.isArray(lastArg)
-            && ('text' in lastArg || 'bgcolor' in lastArg || 'text_color' in lastArg
-                || 'text_size' in lastArg || 'text_halign' in lastArg || 'tooltip' in lastArg
-                || 'column' in lastArg || 'row' in lastArg
-                || 'height' in lastArg || 'width' in lastArg
-                || 'text_valign' in lastArg || 'text_font_family' in lastArg);
+        const hasOpts = isNamedArgs(lastArg, TABLE_CELL_PARAMS);
 
         if (hasOpts) {
             const opts = lastArg;
@@ -227,8 +247,7 @@ export class TableHelper {
         let end_row: any;
 
         const lastArg = args[args.length - 1];
-        const hasOpts = lastArg && typeof lastArg === 'object' && !Array.isArray(lastArg)
-            && ('start_column' in lastArg || 'start_row' in lastArg || 'end_column' in lastArg);
+        const hasOpts = isNamedArgs(lastArg, TABLE_RANGE_PARAMS);
 
         if (hasOpts) {
             const opts = lastArg;
@@ -271,8 +290,7 @@ export class TableHelper {
         let end_row: any;
 
         const lastArg = args[args.length - 1];
-        const hasOpts = lastArg && typeof lastArg === 'object' && !Array.isArray(lastArg)
-            && ('start_column' in lastArg || 'start_row' in lastArg || 'end_column' in lastArg);
+        const hasOpts = isNamedArgs(lastArg, TABLE_RANGE_PARAMS);
 
         if (hasOpts) {
             const opts = lastArg;

--- a/tests/namespaces/table/table-named-args.test.ts
+++ b/tests/namespaces/table/table-named-args.test.ts
@@ -1,0 +1,162 @@
+// Regression tests for named-arg detection in table.* functions.
+//
+// Bug: TableHelper decided whether the trailing transpiler-emitted named-args
+// object was "named args" by checking for a hard-coded subset of parameter
+// keys. Any call whose named args were ALL outside that subset (force_overlay,
+// frame_width, border_width for table.new; end_row for table.clear /
+// table.merge_cells) fell through to positional handling: the object landed in
+// the next positional slot and every value it carried was silently dropped.
+//
+// Expected values come from TradingView: e.g.
+//   table.new(position.bottom_right, 1, 1, force_overlay=true)
+// renders the table on the main chart pane (force_overlay applied, bgcolor default).
+
+import { PineTS } from 'index';
+import { describe, expect, it } from 'vitest';
+
+import { Provider } from '@pinets/marketData/Provider.class';
+
+function newPineTS() {
+    return new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2025-01-01').getTime(), new Date('2025-03-01').getTime());
+}
+
+describe('table.new named-arg detection', () => {
+    it('applies force_overlay=true as the only named argument (case A)', async () => {
+        const { result } = await newPineTS().run((context) => {
+            var t = table.new('bottom_right', 1, 1, { force_overlay: true });
+            var t_force_overlay = t.force_overlay;
+            var t_bgcolor = t.bgcolor;
+            return { t_force_overlay, t_bgcolor };
+        });
+
+        expect(result.t_force_overlay[0]).toBe(true);
+        expect(result.t_bgcolor[0]).toBe('');
+    });
+
+    it('applies frame_width and force_overlay named together (case B)', async () => {
+        const { result } = await newPineTS().run((context) => {
+            var t = table.new('bottom_right', 1, 1, { frame_width: 2, force_overlay: true });
+            var t_frame_width = t.frame_width;
+            var t_force_overlay = t.force_overlay;
+            var t_bgcolor = t.bgcolor;
+            return { t_frame_width, t_force_overlay, t_bgcolor };
+        });
+
+        expect(result.t_frame_width[0]).toBe(2);
+        expect(result.t_force_overlay[0]).toBe(true);
+        expect(result.t_bgcolor[0]).toBe('');
+    });
+
+    it('applies frame_width=2 as the only named argument (case C)', async () => {
+        const { result } = await newPineTS().run((context) => {
+            var t = table.new('bottom_right', 1, 1, { frame_width: 2 });
+            var t_frame_width = t.frame_width;
+            var t_bgcolor = t.bgcolor;
+            return { t_frame_width, t_bgcolor };
+        });
+
+        expect(result.t_frame_width[0]).toBe(2);
+        expect(result.t_bgcolor[0]).toBe('');
+    });
+
+    it('applies border_width=2 as the only named argument (case D)', async () => {
+        const { result } = await newPineTS().run((context) => {
+            var t = table.new('bottom_right', 1, 1, { border_width: 2 });
+            var t_border_width = t.border_width;
+            var t_bgcolor = t.bgcolor;
+            return { t_border_width, t_bgcolor };
+        });
+
+        expect(result.t_border_width[0]).toBe(2);
+        expect(result.t_bgcolor[0]).toBe('');
+    });
+
+    it('recognizes every named parameter of table.new when named alone', async () => {
+        const { result } = await newPineTS().run((context) => {
+            var t1 = table.new('bottom_right', 1, 1, { bgcolor: '#ff0000' });
+            var t2 = table.new('bottom_right', 1, 1, { frame_color: '#00ff00' });
+            var t3 = table.new('bottom_right', 1, 1, { frame_width: 2 });
+            var t4 = table.new('bottom_right', 1, 1, { border_color: '#0000ff' });
+            var t5 = table.new('bottom_right', 1, 1, { border_width: 3 });
+            var t6 = table.new('bottom_right', 1, 1, { force_overlay: true });
+            var v1 = t1.bgcolor;
+            var v2 = t2.frame_color;
+            var v3 = t3.frame_width;
+            var v4 = t4.border_color;
+            var v5 = t5.border_width;
+            var v6 = t6.force_overlay;
+            // bgcolor must stay at its default in every call that does not name it
+            var b2 = t2.bgcolor;
+            var b3 = t3.bgcolor;
+            var b4 = t4.bgcolor;
+            var b5 = t5.bgcolor;
+            var b6 = t6.bgcolor;
+            return { v1, v2, v3, v4, v5, v6, b2, b3, b4, b5, b6 };
+        });
+
+        expect(result.v1[0]).toBe('#ff0000');
+        expect(result.v2[0]).toBe('#00ff00');
+        expect(result.v3[0]).toBe(2);
+        expect(result.v4[0]).toBe('#0000ff');
+        expect(result.v5[0]).toBe(3);
+        expect(result.v6[0]).toBe(true);
+        expect(result.b2[0]).toBe('');
+        expect(result.b3[0]).toBe('');
+        expect(result.b4[0]).toBe('');
+        expect(result.b5[0]).toBe('');
+        expect(result.b6[0]).toBe('');
+    });
+
+    it('applies force_overlay=true end-to-end from native Pine Script source', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("repro", overlay=false)
+plot(close)
+var table t = table.new(position.bottom_right, 1, 1, force_overlay=true)
+if barstate.islast
+    table.cell(t, 0, 0, "X")
+`);
+
+        expect(plots['__tables__']).toBeDefined();
+        const tables = plots['__tables__'].data[0].value;
+        expect(tables.length).toBe(1);
+        expect(tables[0].force_overlay).toBe(true);
+        expect(tables[0].bgcolor).toBe('');
+        expect(tables[0].position).toBe('bottom_right');
+    });
+});
+
+describe('table.clear / table.merge_cells named-arg detection', () => {
+    it('table.clear honors end_row as the only named argument', async () => {
+        const { result } = await newPineTS().run((context) => {
+            var t = table.new('top_right', 1, 3);
+            table.cell(t, 0, 0, 'A');
+            table.cell(t, 0, 1, 'B');
+            table.cell(t, 0, 2, 'C');
+            table.clear(t, 0, 0, 0, { end_row: 1 });
+            var c0 = t.getCell(0, 0);
+            var c1 = t.getCell(0, 1);
+            var c2 = t.getCell(0, 2);
+            return { c0, c1, c2 };
+        });
+
+        // Rows 0 and 1 cleared, row 2 untouched
+        expect(result.c0[0]).toBeFalsy();
+        expect(result.c1[0]).toBeFalsy();
+        expect(result.c2[0].text).toBe('C');
+    });
+
+    it('table.merge_cells honors end_row as the only named argument', async () => {
+        const { result } = await newPineTS().run((context) => {
+            var t = table.new('top_right', 2, 2);
+            table.merge_cells(t, 0, 0, 1, { end_row: 1 });
+            // Writing to a merged cell must redirect to the merge origin (0,0)
+            table.cell(t, 1, 1, 'M');
+            var origin = t.getCell(0, 0);
+            return { origin };
+        });
+
+        expect(result.origin[0]).toBeTruthy();
+        expect(result.origin[0].text).toBe('M');
+    });
+});


### PR DESCRIPTION
## Summary

- Fixes silent named-argument loss in `table.new`: calls whose trailing named args were all outside the hard-coded recognition list (`force_overlay`, `frame_width`, `border_width`) fell through to positional handling — the named-args object landed in the `bgcolor` slot and every value it carried was silently discarded. The idiomatic `table.new(position.bottom_right, 1, 1, force_overlay=true)` produced `force_overlay: false` with `bgcolor` polluted by the swallowed object.
- Also fixes the latent variant in `table.clear` / `table.merge_cells`, whose recognition lists were missing `end_row`: a call naming only `end_row` sent `{end_row: ...}` into the positional slot, making the range loop compare against an object and silently no-op.
- Replaces each ad-hoc key-subset heuristic with a shared `isNamedArgs()` helper driven by complete per-function parameter lists (`TABLE_NEW_PARAMS`, `TABLE_CELL_PARAMS`, `TABLE_RANGE_PARAMS`), so a future parameter only needs to be added to one list. The helper excludes `TableObject` instances, which share property names with `table.new` parameters (`bgcolor`, `position`, ...) and can legitimately appear as a trailing positional argument.

Note on approach: the issue report suggested migrating to `parseArgsForPineParams` as the preferred fix. This PR keeps the positional path untouched instead, because that utility type-checks every positional slot while `TableHelper`'s positional handling is intentionally permissive (arguments may arrive as Series, functions, or NAHelper objects resolved later by `_resolve`) — migrating risked regressing currently-working positional calls without adding coverage.

## Regression tests

New suite `tests/namespaces/table/table-named-args.test.ts` (8 tests), all failing before the fix with exactly the reported symptoms and passing after:

- Cases A–D from the issue's verified matrix (`force_overlay` alone, `frame_width` + `force_overlay`, `frame_width` alone, `border_width` alone).
- The general property: every named parameter of `table.new` applied when named alone, with `bgcolor` left at its default.
- End-to-end native Pine v6 run of the exact repro script (`force_overlay=true` as the only named arg), asserting on the emitted table object.
- `table.clear` and `table.merge_cells` with `end_row` as the only named argument.

## Test plan

- [x] New regression suite fails on the previous code (8/8, symptoms match the issue report) and passes with the fix (8/8)
- [x] Full suite `npm test -- --run`: 1813 passed; the single failure is in gitignored `tests/_local/` and reproduces identically without this change (pre-existing, unrelated)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches argument parsing for all major table APIs; behavior change is intentional for previously broken named-arg paths, with TableObject exclusion guarding a subtle mis-detection edge case.
> 
> **Overview**
> Fixes **silent loss of named arguments** on `table.new`, `table.cell`, `table.clear`, and `table.merge_cells` when the transpiler’s trailing options object only contained keys outside the old hard-coded recognition lists (e.g. `force_overlay`, `frame_width`, `border_width`, or `end_row`). Those calls were treated as positional, so the object was assigned to the wrong slot and its values were dropped—`table.new(..., force_overlay=true)` could leave `force_overlay` false and corrupt `bgcolor`.
> 
> Replaces per-method key heuristics with **`isNamedArgs()`** and **complete parameter lists** (`TABLE_NEW_PARAMS`, `TABLE_CELL_PARAMS`, `TABLE_RANGE_PARAMS`). The helper still rejects **`TableObject`** instances so a trailing table reference (e.g. `table.clear(t)`) is not mistaken for named args.
> 
> Adds regression suite **`table-named-args.test.ts`** (including native Pine v6 `force_overlay=true` and `end_row`-only `clear` / `merge_cells` cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5148abfa1ebd642378407fa518564d174d5ecd43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->