### PR TITLE
Fix user method dispatch on built-in receivers and defaulted params in named args

### DIFF
--- a/src/transpiler/analysis/AnalysisPass.ts
+++ b/src/transpiler/analysis/AnalysisPass.ts
@@ -178,6 +178,15 @@ export function preProcessUdtRegistry(ast: any, scopeManager: ScopeManager): voi
                     const typeName = inferUdtTypeFromInit(decl.init, scopeManager);
                     if (typeName) {
                         scopeManager.markVariableAsUdtInstance(decl.id.name, typeName);
+                        continue;
+                    }
+                    // Not a UDT — try built-in constructor inference
+                    // (`table.new(...)`, `array.from(...)`, ...) so dot-calls
+                    // of user methods on built-in receivers can be dispatched
+                    // by static type matching.
+                    const builtinType = inferBuiltinTypeFromInit(decl.init);
+                    if (builtinType) {
+                        scopeManager.setVarStaticType(decl.id.name, builtinType);
                     }
                     continue;
                 }
@@ -222,6 +231,24 @@ export function preProcessUdtRegistry(ast: any, scopeManager: ScopeManager): voi
                     }
                 }
             }
+            // Explicit built-in / generic type annotations (`var table tb = ...`,
+            // `array<float> eq = ...`) preserved by codegen as
+            // `"__pineTypedVar:<varName>=<type>"` markers.
+            else if (
+                expr?.type === 'Literal' &&
+                typeof expr.value === 'string' &&
+                expr.value.startsWith('__pineTypedVar:')
+            ) {
+                const rest = expr.value.slice('__pineTypedVar:'.length);
+                const eq = rest.indexOf('=');
+                if (eq > 0) {
+                    const varName = rest.slice(0, eq);
+                    const typeName = rest.slice(eq + 1);
+                    if (/^[A-Za-z_$][\w$]*$/.test(varName) && typeName) {
+                        scopeManager.setVarStaticType(varName, typeName);
+                    }
+                }
+            }
         },
     });
 
@@ -240,15 +267,27 @@ export function preProcessUdtRegistry(ast: any, scopeManager: ScopeManager): voi
             if (left?.type !== 'MemberExpression' ||
                 left.computed ||
                 left.property?.type !== 'Identifier' ||
-                left.property.name !== '__pineParamTypes__' ||
                 left.object?.type !== 'Identifier') return;
-            if (expr.right?.type !== 'ObjectExpression') return;
+            const rawName = left.object.name;
             // Methods carry a `$M_` JS-name prefix; strip it so the registry
             // is keyed by the Pine name `transformFunctionDeclaration` will
             // look up at call time.
-            const rawName = left.object.name;
             const funcName = rawName.startsWith('$M_') ? rawName.slice(3) : rawName;
+
+            // `$M_<name>.__pineReceiverType__ = '<type>'` — declared receiver
+            // type of a user `method`, used for dot-call dispatch on built-in
+            // receivers.
+            if (left.property.name === '__pineReceiverType__') {
+                if (expr.right?.type === 'Literal' && typeof expr.right.value === 'string') {
+                    scopeManager.setMethodReceiverType(funcName, expr.right.value);
+                }
+                return;
+            }
+
+            if (left.property.name !== '__pineParamTypes__') return;
+            if (expr.right?.type !== 'ObjectExpression') return;
             const paramTypes: Record<string, string> = {};
+            const rawParamTypes: Record<string, string> = {};
             for (const prop of expr.right.properties) {
                 if (prop.type !== 'Property') continue;
                 // Codegen emits JSON-quoted keys (`"b"`) which acorn parses as
@@ -259,6 +298,7 @@ export function preProcessUdtRegistry(ast: any, scopeManager: ScopeManager): voi
                 else if (prop.key?.type === 'Literal' && typeof prop.key.value === 'string') paramName = prop.key.value;
                 if (!paramName) continue;
                 if (prop.value?.type !== 'Literal' || typeof prop.value.value !== 'string') continue;
+                rawParamTypes[paramName] = prop.value.value;
                 // varType may include qualifiers like 'series BAR' — the type
                 // name is the last whitespace-delimited token.
                 const typeName = prop.value.value.split(/\s+/).pop()!;
@@ -269,8 +309,59 @@ export function preProcessUdtRegistry(ast: any, scopeManager: ScopeManager): voi
             if (Object.keys(paramTypes).length > 0) {
                 scopeManager.setFunctionParamUdtTypes(funcName, paramTypes);
             }
+            // Unfiltered registry: built-in-typed params (e.g. `f(table t)`)
+            // get scope-locally registered in the static-type registry when
+            // entering the function body (see transformFunctionDeclaration).
+            if (Object.keys(rawParamTypes).length > 0) {
+                scopeManager.setFunctionParamStaticTypes(funcName, rawParamTypes);
+            }
         },
     });
+}
+
+/**
+ * Namespaces whose factory calls produce built-in instances that user
+ * `method`s can be declared on. `chart.point` is intentionally absent (its
+ * factories are nested member chains, handled conservatively as unknown).
+ */
+const BUILTIN_INSTANCE_NAMESPACES = new Set(['table', 'line', 'label', 'box', 'linefill', 'polyline', 'array', 'matrix', 'map']);
+
+/**
+ * Inspect an initializer expression and return the built-in BASE type name
+ * ('table', 'array', ...) when it unambiguously constructs a built-in
+ * instance — otherwise undefined. Mirrors `inferUdtTypeFromInit` for
+ * built-in receivers.
+ *
+ * Recognized shapes: `<ns>.new(...)`, `<ns>.copy(...)`, `<ns>.from(...)`,
+ * `<ns>.new_<type>(...)` (array typed constructors), plus ternaries where
+ * both branches resolve to the same type.
+ */
+function inferBuiltinTypeFromInit(init: any): string | undefined {
+    if (!init) return undefined;
+
+    if (
+        init.type === 'CallExpression' &&
+        init.callee?.type === 'MemberExpression' &&
+        !init.callee.computed &&
+        init.callee.object?.type === 'Identifier' &&
+        init.callee.property?.type === 'Identifier' &&
+        BUILTIN_INSTANCE_NAMESPACES.has(init.callee.object.name)
+    ) {
+        const method = init.callee.property.name;
+        if (method === 'new' || method === 'copy' || method === 'from' || method.startsWith('new_')) {
+            return init.callee.object.name;
+        }
+    }
+
+    if (init.type === 'ConditionalExpression') {
+        const consequentType = inferBuiltinTypeFromInit(init.consequent);
+        const alternateType = inferBuiltinTypeFromInit(init.alternate);
+        if (consequentType && consequentType === alternateType) {
+            return consequentType;
+        }
+    }
+
+    return undefined;
 }
 
 /**

--- a/src/transpiler/analysis/ScopeManager.ts
+++ b/src/transpiler/analysis/ScopeManager.ts
@@ -40,6 +40,25 @@ const JS_GLOBAL_OBJECTS = new Set([
     'decodeURIComponent',
 ]);
 
+/**
+ * Reduce a Pine type annotation to its BASE type name:
+ *   'array<float>'        → 'array'
+ *   'series table'        → 'table'
+ *   'simple string'       → 'string'
+ *   'matrix<int>'         → 'matrix'
+ *   'MyType'              → 'MyType'
+ * Generic arguments are stripped first, then qualifier prefixes
+ * (series/simple/const/input/...) by taking the last whitespace token.
+ */
+export function normalizePineBaseType(pineType: string | undefined): string | undefined {
+    if (!pineType || typeof pineType !== 'string') return undefined;
+    let s = pineType.trim();
+    const lt = s.indexOf('<');
+    if (lt >= 0) s = s.slice(0, lt);
+    const parts = s.split(/\s+/).filter(Boolean);
+    return parts.length > 0 ? parts[parts.length - 1] : undefined;
+}
+
 export class ScopeManager {
     private scopes: Map<string, string>[] = [];
     private scopeTypes: string[] = [];
@@ -135,6 +154,37 @@ export class ScopeManager {
      * function scope, keeping the global registry clean.
      */
     private functionParamUdtTypes: Map<string, Record<string, string>> = new Map();
+
+    /**
+     * Registry of variable names → static Pine BASE type ('table', 'array',
+     * 'line', ...). Populated from `__pineTypedVar:` markers (explicit
+     * annotations like `var table tb = ...`) and from built-in constructor
+     * initializers (`tb = table.new(...)`, `eq = array.from(...)`).
+     *
+     * Consumed by the dot-call dispatch in `transformCallExpression`: a user
+     * `method` declared on a built-in receiver type (e.g. `method cell(table
+     * tb, ...)`) must win over the built-in member when the receiver's static
+     * type matches the method's declared first-parameter type (TV semantics).
+     */
+    private varStaticTypes: Map<string, string> = new Map();
+
+    /**
+     * Registry of user `method` Pine names → declared receiver BASE type
+     * (first-parameter type, e.g. 'table' for `method cell(table tb, ...)`).
+     * Populated from `$M_<name>.__pineReceiverType__ = '...'` markers emitted
+     * by pine2js codegen.
+     */
+    private methodReceiverTypes: Map<string, string> = new Map();
+
+    /**
+     * Registry of user-defined function names → map of {paramName → BASE
+     * type} for ALL type-annotated params (unlike `functionParamUdtTypes`,
+     * which is filtered to UDT types). Consumed by
+     * `transformFunctionDeclaration` to scope-locally register built-in-typed
+     * params (e.g. `f(table t)`) in `varStaticTypes` so dot-calls of user
+     * methods on those params dispatch correctly inside the body.
+     */
+    private functionParamStaticTypes: Map<string, Record<string, string>> = new Map();
 
     public get nextParamIdArg(): any {
         return {
@@ -323,6 +373,41 @@ export class ScopeManager {
      */
     unmarkVariableAsUdtInstance(varName: string): void {
         this.udtInstances.delete(varName);
+    }
+
+    // ── Static (built-in) type registry ─────────────────────────────────
+    // Mirrors the UDT registry for BUILT-IN receiver types (table, array,
+    // line, ...) so user `method`s declared on built-in types can be
+    // dispatched by declared-receiver-type matching at dot-call sites.
+
+    setVarStaticType(varName: string, pineType: string): void {
+        const base = normalizePineBaseType(pineType);
+        if (base) this.varStaticTypes.set(varName, base);
+    }
+
+    getVarStaticType(varName: string): string | undefined {
+        return this.varStaticTypes.get(varName);
+    }
+
+    unsetVarStaticType(varName: string): void {
+        this.varStaticTypes.delete(varName);
+    }
+
+    setMethodReceiverType(pineName: string, pineType: string): void {
+        const base = normalizePineBaseType(pineType);
+        if (base) this.methodReceiverTypes.set(pineName, base);
+    }
+
+    getMethodReceiverType(pineName: string): string | undefined {
+        return this.methodReceiverTypes.get(pineName);
+    }
+
+    setFunctionParamStaticTypes(funcName: string, paramTypes: Record<string, string>): void {
+        this.functionParamStaticTypes.set(funcName, paramTypes);
+    }
+
+    getFunctionParamStaticTypes(funcName: string): Record<string, string> | undefined {
+        return this.functionParamStaticTypes.get(funcName);
     }
 
     addContextBoundVar(name: string, isRootParam: boolean = false): void {

--- a/src/transpiler/pineToJS/codegen.ts
+++ b/src/transpiler/pineToJS/codegen.ts
@@ -605,6 +605,19 @@ export class CodeGenerator {
         if (isMethod) {
             this.write(this.indentStr.repeat(this.indent));
             this.write(`${jsFnName}.__pineMethod__ = true;\n`);
+
+            // Emit the declared receiver type (first-parameter type) so the
+            // transpile phase can dispatch dot-calls on BUILT-IN receivers
+            // (e.g. `method cell(table tb, ...)` called as `tb.cell(...)`)
+            // to the user method by static type matching. Emitted separately
+            // from __pineParamTypes__ because that marker skips the receiver
+            // when it is named `this` (renamed to `self`).
+            const recvParam = node.params[0];
+            const recvType = recvParam?.type === 'AssignmentPattern' ? recvParam.left?.varType : recvParam?.varType;
+            if (typeof recvType === 'string' && recvType.length > 0) {
+                this.write(this.indentStr.repeat(this.indent));
+                this.write(`${jsFnName}.__pineReceiverType__ = ${JSON.stringify(recvType)};\n`);
+            }
         }
 
         // Emit param-type marker for any params that carried a Pine type
@@ -714,6 +727,13 @@ export class CodeGenerator {
             ) {
                 this.write(this.indentStr.repeat(this.indent));
                 this.write(`"__pineUdtVar:${declaredName}=${declaredType}";\n`);
+            } else if (declaredName && typeof declaredType === 'string' && declaredType.length > 0) {
+                // Built-in / generic type annotations (`table`, `array<float>`,
+                // `series float`, ...) — preserved so the AnalysisPass can
+                // register the variable's static type for user-method
+                // dot-call dispatch on built-in receivers.
+                this.write(this.indentStr.repeat(this.indent));
+                this.write(`${JSON.stringify(`__pineTypedVar:${declaredName}=${declaredType}`)};\n`);
             }
         }
     }

--- a/src/transpiler/transformers/ExpressionTransformer.ts
+++ b/src/transpiler/transformers/ExpressionTransformer.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 LuxAlgo
 
 import * as walk from 'acorn-walk';
-import ScopeManager from '../analysis/ScopeManager';
+import ScopeManager, { normalizePineBaseType } from '../analysis/ScopeManager';
 import { ASTFactory, CONTEXT_NAME } from '../utils/ASTFactory';
 import { KNOWN_NAMESPACES, NAMESPACES_LIKE, ASYNC_METHODS, CALLSITE_ID_NAMESPACES } from '../settings';
 
@@ -1652,17 +1652,7 @@ export function transformCallExpression(node: any, scopeManager: ScopeManager, n
         // Check if methodName is a user-defined function (and not a built-in property like push/pop/size unless shadowed?)
         const isUserFunction = scopeManager.isUserFunction(methodName);
 
-        // Guard: if the object is a function parameter, this is a built-in method
-        // call on a typed argument (e.g. t.cell() where t is a table param),
-        // NOT a call to the user function with the same name. Skip transformation.
         const _obj = node.callee.object;
-        const isBuiltinMethodOnParam = _obj.type === 'Identifier' && scopeManager.isLocalSeriesVar(_obj.name);
-
-        // Guard: if the callee object is a MemberExpression (property chain like
-        // aZZ.x.set(0, val)), this is a method call on a sub-property, NOT a user
-        // function call.  User function method calls only happen on direct variable
-        // references (e.g. obj.method(args) where obj is an Identifier).
-        const isChainedPropertyMethod = _obj.type === 'MemberExpression';
 
         // Only allow obj.method(args) → method(obj, args) for functions declared
         // with the Pine `method` keyword.  Regular functions (without `method`)
@@ -1670,17 +1660,48 @@ export function transformCallExpression(node: any, scopeManager: ScopeManager, n
         // method call on the object, never a call to a user-defined function.
         const isUserMethod = scopeManager.isUserMethod(methodName);
 
-        // Receiver-type guard: only retarget `obj.method()` when `obj` is a known
-        // UDT instance. Without this guard, names that collide with user methods
-        // would also retarget for built-in receivers — e.g. a `method delete(...)`
-        // declared on a UDT would hijack `someLine.delete()` calls. Narrowing on
-        // `isUdtInstance` keeps built-in calls intact.
-        // The receiver may have already been wrapped into a `$.get(...)` call by
-        // an earlier pass — but the original Identifier name is preserved on
-        // the wrapper as `.name`, so a single lookup covers both shapes.
+        // ── Receiver-type dispatch (TV semantics) ─────────────────────────
+        // A user `method` wins over a built-in member when the receiver's
+        // STATIC type matches the method's declared first-parameter type —
+        // including name collisions with built-ins (`method cell(table tb,…)`
+        // shadows `table.cell` for table receivers) and receivers that are
+        // function params or UDT property chains.
+        //
+        // Static receiver type sources, in order:
+        //   1. UDT instance registry (incl. scope-locally marked UDT params)
+        //   2. Built-in static-type registry (explicit annotations via
+        //      `__pineTypedVar:` markers, initializer inference like
+        //      `table.new(...)`, scope-locally marked built-in-typed params)
+        //   3. UDT field chains (`bs.is_equity.to_sparkline()`) via the UDT
+        //      field-type metadata.
+        //
+        // The receiver may have already been wrapped into a `$.get(...)` call
+        // by an earlier pass — but the original Identifier name is preserved
+        // on the wrapper as `.name`, so a single lookup covers both shapes.
+        let receiverBaseType: string | undefined;
+        if (_obj.name) {
+            receiverBaseType = scopeManager.getVariableUdtType(_obj.name) ?? scopeManager.getVarStaticType(_obj.name);
+        } else if (_obj.type === 'MemberExpression' && !_obj.computed && _obj.property?.type === 'Identifier' && _obj.object?.name) {
+            const baseUdtType = scopeManager.getVariableUdtType(_obj.object.name);
+            if (baseUdtType) {
+                const fieldType = scopeManager.getUdtTypeFields(baseUdtType)?.[_obj.property.name];
+                receiverBaseType = normalizePineBaseType(fieldType);
+            }
+        }
+        const methodReceiverType = scopeManager.getMethodReceiverType(methodName);
+        const receiverTypeMatches = !!receiverBaseType && !!methodReceiverType && receiverBaseType === methodReceiverType;
+
+        // UDT-instance dispatch (pre-existing rule, kept as a fallback for
+        // methods whose declared receiver type could not be extracted): a
+        // direct reference to a known UDT instance always dispatches to the
+        // user method — UDT instances have no built-in members to call.
+        // When neither rule applies (receiver type unknown/mismatched and
+        // not a UDT instance), the call falls through to the built-in — a
+        // name that merely collides with a user method must not hijack e.g.
+        // `someLine.delete()`.
         const isReceiverUdtInstance = !!_obj.name && scopeManager.isUdtInstance(_obj.name);
 
-        if (isUserFunction && isUserMethod && !scopeManager.isContextBound(methodName) && !isBuiltinMethodOnParam && !isChainedPropertyMethod && isReceiverUdtInstance) {
+        if (isUserFunction && isUserMethod && !scopeManager.isContextBound(methodName) && (receiverTypeMatches || isReceiverUdtInstance)) {
             // It's a user variable/function.
             // Transform obj.method(args) -> method(obj, args)
             // 1. Get the object (first arg)
@@ -1705,6 +1726,9 @@ export function transformCallExpression(node: any, scopeManager: ScopeManager, n
             } else if (obj.type === 'CallExpression') {
                  // If object is a call expression, transform it first
                  transformCallExpression(obj, scopeManager);
+                 transformedObj = transformFunctionArgument(obj, CONTEXT_NAME, scopeManager);
+            } else if (obj.type === 'MemberExpression') {
+                 // UDT field chain receiver (e.g. `bs.is_equity.to_sparkline()`)
                  transformedObj = transformFunctionArgument(obj, CONTEXT_NAME, scopeManager);
             }
 

--- a/src/transpiler/transformers/StatementTransformer.ts
+++ b/src/transpiler/transformers/StatementTransformer.ts
@@ -1494,9 +1494,15 @@ export function transformFunctionDeclaration(node: any, scopeManager: ScopeManag
         // This ensures they:
         // 1. Stay as plain identifiers (no renaming to $.let.scoped_name)
         // 2. Get $.get() wrapping when used (e.g., X1.size() → $.get(X1, 0).size())
+        // Parameters with a default value are AssignmentPattern nodes — the
+        // bound name is on `.left`. Skipping them made references to defaulted
+        // params inside named-arg object literals resolve through the global
+        // context (`$.let.<name>` → undefined) instead of the JS parameter.
         node.params.forEach((param: any) => {
             if (param.type === 'Identifier') {
                 scopeManager.addLocalSeriesVar(param.name);
+            } else if (param.type === 'AssignmentPattern' && param.left?.type === 'Identifier') {
+                scopeManager.addLocalSeriesVar(param.left.name);
             }
         });
 
@@ -1522,6 +1528,19 @@ export function transformFunctionDeclaration(node: any, scopeManager: ScopeManag
             }
         }
 
+        // Same scope-local registration for BUILT-IN-typed params (e.g.
+        // `f(table t)`), from the unfiltered param-type registry, so dot-calls
+        // of user methods on those params (`t.divider(0)`) dispatch by static
+        // receiver-type matching inside the body.
+        const rawParamTypes = fnName ? scopeManager.getFunctionParamStaticTypes(fnName) : undefined;
+        const savedStaticBindings: Record<string, string | undefined> = {};
+        if (rawParamTypes) {
+            for (const [paramName, typeName] of Object.entries(rawParamTypes)) {
+                savedStaticBindings[paramName] = scopeManager.getVarStaticType(paramName);
+                scopeManager.setVarStaticType(paramName, typeName);
+            }
+        }
+
         // Just delegate to the callback to continue the recursion
         c(node.body, scopeManager);
 
@@ -1529,6 +1548,8 @@ export function transformFunctionDeclaration(node: any, scopeManager: ScopeManag
         node.params.forEach((param: any) => {
             if (param.type === 'Identifier') {
                 scopeManager.removeLocalSeriesVar(param.name);
+            } else if (param.type === 'AssignmentPattern' && param.left?.type === 'Identifier') {
+                scopeManager.removeLocalSeriesVar(param.left.name);
             }
         });
         if (paramTypes) {
@@ -1537,6 +1558,15 @@ export function transformFunctionDeclaration(node: any, scopeManager: ScopeManag
                 const prev = savedUdtBindings[paramName];
                 if (prev !== undefined) {
                     scopeManager.markVariableAsUdtInstance(paramName, prev);
+                }
+            }
+        }
+        if (rawParamTypes) {
+            for (const paramName of Object.keys(rawParamTypes)) {
+                scopeManager.unsetVarStaticType(paramName);
+                const prev = savedStaticBindings[paramName];
+                if (prev !== undefined) {
+                    scopeManager.setVarStaticType(paramName, prev);
                 }
             }
         }

--- a/tests/transpiler/defaulted-param-named-args.test.ts
+++ b/tests/transpiler/defaulted-param-named-args.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+// Regression guard: a function parameter WITH a default value, referenced as a
+// value inside a named-argument object literal, must resolve to the JS
+// parameter — not to a (non-existent) `$.let.<name>` global context slot.
+describe('defaulted params referenced in named-argument object literals', () => {
+    const makePineTS = () =>
+        new PineTS(Provider.Mock, 'BTCUSDC', 'W', null, new Date('2019-01-01').getTime(), new Date('2019-03-01').getTime());
+
+    it('defaulted param forwarded via named arg keeps its value (default used)', async () => {
+        const pineTS = makePineTS();
+        const code = `
+//@version=6
+indicator("m")
+f_reg_def(table tb, color c = #00ff00) =>
+    table.cell(tb, 0, 0, "A", text_color=c)
+method m_nodef(table tb, color c) =>
+    table.cell(tb, 1, 0, "B", text_color=c)
+var table tb = table.new(position.top_right, 2, 1)
+if barstate.islast
+    f_reg_def(tb)
+    m_nodef(tb, #123456)
+plot(close)
+`;
+        const { plots } = await pineTS.run(code);
+        const tbl = plots['__tables__']?.data?.at(-1)?.value?.[0];
+        expect(tbl).toBeDefined();
+
+        // Cell A: defaulted param `c` forwarded as `text_color=c` — must be the default.
+        expect(tbl.cells[0][0]?.text).toBe('A');
+        expect(tbl.cells[0][0]?.text_color).toBe('#00ff00');
+
+        // Cell B: non-defaulted param (control) — already worked, must keep working.
+        expect(tbl.cells[0][1]?.text).toBe('B');
+        expect(tbl.cells[0][1]?.text_color).toBe('#123456');
+    });
+
+    it('defaulted param forwarded via named arg keeps its value (explicit argument)', async () => {
+        const pineTS = makePineTS();
+        const code = `
+//@version=6
+indicator("m")
+f_reg_def(table tb, color c = #00ff00, string al = text.align_center) =>
+    table.cell(tb, 0, 0, "A", text_color=c, text_halign=al)
+var table tb = table.new(position.top_right, 1, 1)
+if barstate.islast
+    f_reg_def(tb, #ff8800, text.align_right)
+plot(close)
+`;
+        const { plots } = await pineTS.run(code);
+        const tbl = plots['__tables__']?.data?.at(-1)?.value?.[0];
+        expect(tbl.cells[0][0]?.text_color).toBe('#ff8800');
+        expect(tbl.cells[0][0]?.text_halign).toBe('right');
+    });
+
+    it('defaulted param still works in arithmetic and positional args (control)', async () => {
+        const pineTS = makePineTS();
+        const code = `
+//@version=6
+indicator("m")
+f_calc(float v = 21) =>
+    math.max(v * 2, 0)
+plot(f_calc())
+`;
+        const { plots } = await pineTS.run(code);
+        const plotKey = Object.keys(plots)[0];
+        expect(plots[plotKey].data.at(-1)?.value).toBe(42);
+    });
+});

--- a/tests/transpiler/user-method-builtin-receiver.test.ts
+++ b/tests/transpiler/user-method-builtin-receiver.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+// Regression guard: user-defined `method`s declared on BUILT-IN receiver types
+// (table, array<float>, ...) must dispatch when called with dot syntax, exactly
+// like they do on TradingView. Three failure shapes are covered:
+//   1. method name collides with a built-in member (`cell`) — user method must win
+//   2. method name is not a built-in member (`divider`) — must not be a silent no-op
+//   3. expression-position call (`eq.to_sparkline()`) — must not evaluate to undefined
+describe('user method dispatch on built-in receivers (dot syntax)', () => {
+    const makePineTS = () =>
+        new PineTS(Provider.Mock, 'BTCUSDC', 'W', null, new Date('2019-01-01').getTime(), new Date('2019-03-01').getTime());
+
+    it('dot-calls of user methods on a table / array receiver dispatch to the user method', async () => {
+        const pineTS = makePineTS();
+        const code = `
+//@version=6
+indicator("m")
+method cell(table tb, int col, int row, string txt, color txt_color=#DBDBDB, string align=text.align_center) =>
+    table.cell(tb, col, row, txt, text_color=txt_color, text_size=10, text_halign=align, bgcolor=na)
+method divider(table tb, int row, int last_col) =>
+    table.merge_cells(tb, 0, row, last_col, row)
+    table.cell(tb, 0, row, "DIVIDER", text_color=#2E2E2E)
+method to_sparkline(array<float> arr) =>
+    arr.size() > 1 ? "SPARK" : "N/A"
+var table tb = table.new(position.top_right, 3, 3)
+var array<float> eq = array.from(1.0, 2.0, 3.0)
+if barstate.islast
+    tb.cell(0, 0, "Metric", #808080, text.align_left)
+    tb.divider(1, 2)
+    tb.cell(0, 2, eq.to_sparkline(), #089981, text.align_right)
+plot(close)
+`;
+        const { plots } = await pineTS.run(code);
+        const tables = plots['__tables__']?.data?.at(-1)?.value;
+        expect(tables).toBeDefined();
+        expect(tables.length).toBe(1);
+        const tbl = tables[0];
+
+        // Shape 1: name collision with built-in `table.cell` — the user method
+        // must run: color goes to text_color (NOT width), align to text_halign
+        // (NOT height), text_size forwarded.
+        const c00 = tbl.cells[0][0];
+        expect(c00).toBeTruthy();
+        expect(c00.text).toBe('Metric');
+        expect(c00.text_color).toBe('#808080');
+        expect(c00.text_halign).toBe('left');
+        expect(c00.text_size).toBe(10);
+        expect(c00.width).not.toBe('#808080');
+        expect(c00.height).not.toBe('left');
+
+        // Shape 2: `divider` is not a built-in table member — must not be a no-op.
+        expect(tbl.merges).toEqual([{ startCol: 0, startRow: 1, endCol: 2, endRow: 1 }]);
+        const c10 = tbl.cells[1][0];
+        expect(c10).toBeTruthy();
+        expect(c10.text).toBe('DIVIDER');
+        expect(c10.text_color).toBe('#2E2E2E');
+
+        // Shape 3: expression-position dot-call on an array receiver.
+        const c20 = tbl.cells[2][0];
+        expect(c20).toBeTruthy();
+        expect(c20.text).toBe('SPARK');
+        expect(c20.text_color).toBe('#089981');
+        expect(c20.text_halign).toBe('right');
+    });
+
+    it('user method dot-call on a built-in receiver inside a function body (param receiver)', async () => {
+        const pineTS = makePineTS();
+        const code = `
+//@version=6
+indicator("m")
+method divider(table tb, int row) =>
+    table.cell(tb, 0, row, "DIV")
+f_draw(table t) =>
+    t.divider(0)
+var table tb = table.new(position.top_right, 1, 1)
+if barstate.islast
+    f_draw(tb)
+plot(close)
+`;
+        const { plots } = await pineTS.run(code);
+        const tbl = plots['__tables__']?.data?.at(-1)?.value?.[0];
+        expect(tbl).toBeDefined();
+        expect(tbl.cells[0][0]?.text).toBe('DIV');
+    });
+
+    it('user method dot-call on a UDT field chain receiver (array<float> field)', async () => {
+        const pineTS = makePineTS();
+        const code = `
+//@version=6
+indicator("m")
+type Stats
+    array<float> is_equity
+method to_sparkline(array<float> arr) =>
+    arr.size() > 1 ? "SPARK" : "N/A"
+var Stats bs = Stats.new(is_equity = array.from(1.0, 2.0, 3.0))
+var table tb = table.new(position.top_right, 1, 1)
+if barstate.islast
+    tb.cell(0, 0, bs.is_equity.to_sparkline())
+plot(close)
+`;
+        const { plots } = await pineTS.run(code);
+        const tbl = plots['__tables__']?.data?.at(-1)?.value?.[0];
+        expect(tbl).toBeDefined();
+        expect(tbl.cells[0][0]?.text).toBe('SPARK');
+    });
+
+    it('does not hijack built-in calls when no user method matches', async () => {
+        const pineTS = makePineTS();
+        const code = `
+//@version=6
+indicator("m")
+var table tb = table.new(position.top_right, 1, 1)
+var array<float> a = array.from(1.0, 2.0)
+if barstate.islast
+    tb.cell(0, 0, "plain", text_color=#112233)
+    a.push(3.0)
+plot(a.size())
+`;
+        const { plots } = await pineTS.run(code);
+        const tbl = plots['__tables__']?.data?.at(-1)?.value?.[0];
+        expect(tbl.cells[0][0]?.text).toBe('plain');
+        expect(tbl.cells[0][0]?.text_color).toBe('#112233');
+        const sizes = plots['plot(a.size())'] ?? plots[Object.keys(plots).find((k) => k !== '__tables__') as string];
+        expect(sizes.data.at(-1)?.value).toBe(3);
+    });
+
+    it('UDT method named like a built-in still dispatches on UDT receivers, built-in receivers keep built-in', async () => {
+        const pineTS = makePineTS();
+        // `method delete(MyBox b)` must not hijack `ln.delete()` on a line —
+        // this is the case the original receiver guard protected.
+        const code = `
+//@version=6
+indicator("m")
+type MyBox
+    float v
+method delete(MyBox b) =>
+    b.v := -1
+var MyBox mb = MyBox.new(5)
+var line ln = line.new(na, na, na, na)
+if barstate.islast
+    mb.delete()
+    ln.delete()
+plot(mb.v)
+`;
+        const { plots } = await pineTS.run(code);
+        const plotKey = Object.keys(plots).find((k) => k !== '__tables__') as string;
+        expect(plots[plotKey].data.at(-1)?.value).toBe(-1);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes two independent transpiler bugs that break user-defined `method`s declared on built-in types (discovered via the *Moving Average: Out-of-Sample Optimizer [LuxAlgo]* dashboard, which loses all text colors, alignment, divider rows, and sparklines under PineTS while rendering correctly on TradingView).

### Bug 1 — dot-calls of user methods on built-in receivers never dispatch

`tb.cell(...)`, `tb.divider(...)`, `eq.to_sparkline()` (with `method cell(table tb, ...)` etc. declared) never reached the user method: the retarget in `ExpressionTransformer` was gated on the receiver being a UDT instance, so built-in-typed receivers fell through to the built-in object via optional chaining — mismatched positional mapping on name collision (`cell`: color→`width`, align→`height`), silent no-op otherwise. UFCS calls (`divider(tb, 1, 2)`) already dispatched correctly; only dot syntax was broken.

Dispatch now matches TV semantics: a user `method` wins over a built-in member when the receiver's **static type** matches the method's declared first-parameter type. Static types come from:

- new `__pineReceiverType__` codegen marker on each compiled method (separate from `__pineParamTypes__`, which skips `this`/`self` receivers)
- new `__pineTypedVar:` codegen marker for built-in/generic declared types (`var table tb`, `array<float> eq`) that the UDT-only marker dropped
- initializer inference (`table.new(...)`, `array.from(...)`, ternaries)
- typed function params (`f_draw(table t)`), scope-locally registered like UDT params
- UDT field chains (`bs.is_equity.to_sparkline()`) via UDT field-type metadata

The pre-existing UDT-instance rule is kept as fallback, and a name that merely collides with a user method still does not hijack built-in calls on unrelated receivers (`someLine.delete()` with `method delete(MyBox b)` declared).

### Bug 2 — defaulted params referenced in named-arg object literals resolve to `$.let.<name>`

A parameter **with a default value** referenced inside a named-argument object literal (`table.cell(tb, 0, 0, "A", text_color=c)` with `color c = #00ff00`) emitted `text_color: $.let.c` — a global-context lookup that can never resolve (wrong scope and missing scope prefix) — silently dropping the value. Root cause: defaulted params are `AssignmentPattern` nodes and `transformFunctionDeclaration` only registered `Identifier` params as local series vars. Registering `param.left.name` (with symmetric cleanup on scope exit) makes defaulted params take the same bare-identifier path as non-defaulted ones.

Note: fixing Bug 1 alone would not restore the dashboard colors — `cell`''s `txt_color`/`align` params have defaults and forward via `text_color=`/`text_halign=`, hitting Bug 2. The regression tests cover the combined path.

## Test plan

- [x] Both bugs reproduced as failing tests first (4 failures on `dev`), now passing
- [x] `tests/transpiler/user-method-builtin-receiver.test.ts` — all three Bug 1 failure shapes (built-in name collision, non-colliding no-op, expression-position call) + param receiver, UDT field chain, no-hijack control, UDT collision control
- [x] `tests/transpiler/defaulted-param-named-args.test.ts` — default used, explicit argument, arithmetic/positional controls
- [x] Full suite: 1813 passed, no regressions (only pre-existing failure is in gitignored `tests/_local/`)
- [x] No conflicts with open PRs #287/#288 (verified via test merges; disjoint file sets)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core dot-call dispatch and function-parameter scoping in the transpiler; behavior is well-covered by new tests but touches expression and statement transformation paths used broadly at runtime.
> 
> **Overview**
> Fixes two transpiler bugs that broke dashboards using user `method`s on built-in types (`table`, `array`, etc.) and named arguments that forward defaulted parameters.
> 
> **User methods on built-in receivers (`tb.cell`, `tb.divider`, `eq.to_sparkline`)** previously only retargeted dot-calls when the receiver was a UDT instance, so built-in receivers hit native members (wrong args on name collisions, silent no-ops otherwise). Dispatch now follows TradingView semantics: a user `method` wins when the receiver’s **static base type** matches the method’s declared first-parameter type. That static typing is fed by new codegen markers (`__pineReceiverType__`, `__pineTypedVar:`), built-in initializer inference (`table.new`, `array.from`, …), scope-local registration for typed function params, and UDT field chains. UDT-instance dispatch remains as fallback; colliding method names still do not hijack unrelated built-in calls (e.g. `ln.delete()` vs `method delete(MyBox b)`).
> 
> **Defaulted parameters in named-arg object literals** (`text_color=c` with `color c = #00ff00`) wrongly resolved to `$.let.c` because `AssignmentPattern` params were not registered as local series variables. Registering `param.left.name` (with cleanup on scope exit) aligns them with normal params.
> 
> Adds regression tests for both areas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bccb1d05464b5f2a190427a2fdb2fb7bd7ece2e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->