### PR TITLE
Throw PineRuntimeError on out-of-bounds array/matrix access (TV parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [Unreleased]
+
+### Fixed
+
+- **Out-of-bounds array/matrix access no longer fails silently — TV parity restored**: `array.get/set/insert/remove` and `matrix.get/set/row/col` emitted a non-blocking `context.warn()` and returned `na`/no-op on an out-of-bounds index, so scripts like `array.new<float>(0)` + `a.get(2)` ran to completion instead of halting. TradingView raises a runtime error here ("Index xx is out of bounds. Array size is yy" — see the Pine docs on arrays). These methods now throw the catchable `PineRuntimeError` (with `method` set to the offending call, e.g. `'array.get'`); v6 negative-index normalization is unchanged, and the reported index is the one the script passed (not the normalized one). `stream()` consumers now receive an `'error'` event instead of a `'warning'` for these violations. New regression suite: `tests/namespaces/array/oob-runtime-error.test.ts` (includes the original report's script); `bounds-check`, `negative-index` and `runtime-error-capture` tests updated to expect the throw.
+
+---
+
 ## [0.9.32] - 2026-08-24 - Session Support, `runtime.error` & Version-Accurate Integer Division
 
 ### Fixed

--- a/docs/initialization-and-usage.md
+++ b/docs/initialization-and-usage.md
@@ -352,7 +352,7 @@ evt.on('alert', (alert) => {
     console.log('Alert:', alert.message);
 });
 
-// Handle runtime warnings (non-blocking, e.g. array OOB)
+// Handle runtime warnings (non-blocking)
 evt.on('warning', (warning) => {
     console.warn('Warning:', warning.message);
 });
@@ -564,7 +564,7 @@ interface Context {
     result: any; // Computed results
     plots: any; // Plot data
     alerts: any[]; // Alert events from alert() and alertcondition()
-    warnings: any[]; // Runtime warnings (e.g. array OOB)
+    warnings: any[]; // Non-blocking runtime warnings
 
     // Market context
     marketData: any[]; // Raw market data

--- a/src/namespaces/array/methods/get.ts
+++ b/src/namespaces/array/methods/get.ts
@@ -1,22 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { PineArrayObject } from '../PineArrayObject';
+import { PineRuntimeError } from '../../../errors/PineRuntimeError';
 
 export function get(context: any) {
     return (id: PineArrayObject, index: number) => {
         // Pine Script v6: negative indices count backwards from the end.
         // -1 = last element, -array.size() = first element.
-        if (index < 0) index = id.array.length + index;
-        // Bounds check: warn and return NaN (Pine's na) for out-of-bounds access.
-        // TradingView throws a runtime error, but PineTS emits a non-blocking
-        // warning so partial results are still available.
-        if (index < 0 || index >= id.array.length) {
-            context.warn(
+        const resolved = index < 0 ? id.array.length + index : index;
+        // TradingView halts the script with a runtime error on out-of-bounds access.
+        if (resolved < 0 || resolved >= id.array.length) {
+            throw new PineRuntimeError(
                 `Index ${index} is out of bounds, array size is ${id.array.length}.`,
                 'array.get'
             );
-            return NaN;
         }
-        return id.array[index];
+        return id.array[resolved];
     };
 }

--- a/src/namespaces/array/methods/insert.ts
+++ b/src/namespaces/array/methods/insert.ts
@@ -2,6 +2,7 @@
 
 import { PineArrayObject } from '../PineArrayObject';
 import { isValueOfType } from '../utils';
+import { PineRuntimeError } from '../../../errors/PineRuntimeError';
 
 export function insert(context: any) {
     return (id: PineArrayObject, index: number, value: any): void => {
@@ -13,15 +14,15 @@ export function insert(context: any) {
             );
         }
         // Pine Script v6: negative indices count backwards from the end.
-        if (index < 0) index = id.array.length + index;
+        const resolved = index < 0 ? id.array.length + index : index;
         // For insert, valid indices are 0 to array.length (inclusive — insert at end is valid).
-        if (index < 0 || index > id.array.length) {
-            context.warn(
+        // TradingView halts the script with a runtime error on out-of-bounds access.
+        if (resolved < 0 || resolved > id.array.length) {
+            throw new PineRuntimeError(
                 `Index ${index} is out of bounds, array size is ${id.array.length}.`,
                 'array.insert'
             );
-            return;
         }
-        id.array.splice(index, 0, value);
+        id.array.splice(resolved, 0, value);
     };
 }

--- a/src/namespaces/array/methods/remove.ts
+++ b/src/namespaces/array/methods/remove.ts
@@ -1,18 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { PineArrayObject } from '../PineArrayObject';
+import { PineRuntimeError } from '../../../errors/PineRuntimeError';
 
 export function remove(context: any) {
     return (id: PineArrayObject, index: number): any => {
         // Pine Script v6: negative indices count backwards from the end.
-        if (index < 0) index = id.array.length + index;
-        if (index < 0 || index >= id.array.length) {
-            context.warn(
+        const resolved = index < 0 ? id.array.length + index : index;
+        // TradingView halts the script with a runtime error on out-of-bounds access.
+        if (resolved < 0 || resolved >= id.array.length) {
+            throw new PineRuntimeError(
                 `Index ${index} is out of bounds, array size is ${id.array.length}.`,
                 'array.remove'
             );
-            return NaN;
         }
-        return id.array.splice(index, 1)[0];
+        return id.array.splice(resolved, 1)[0];
     };
 }

--- a/src/namespaces/array/methods/set.ts
+++ b/src/namespaces/array/methods/set.ts
@@ -3,6 +3,7 @@
 import { PineArrayObject } from '../PineArrayObject';
 import { isValueOfType } from '../utils';
 import { Context } from '../../../Context.class';
+import { PineRuntimeError } from '../../../errors/PineRuntimeError';
 
 export function set(context: Context) {
     return (id: PineArrayObject, index: number, value: any) => {
@@ -14,14 +15,14 @@ export function set(context: Context) {
             );
         }
         // Pine Script v6: negative indices count backwards from the end.
-        if (index < 0) index = id.array.length + index;
-        if (index < 0 || index >= id.array.length) {
-            context.warn(
+        const resolved = index < 0 ? id.array.length + index : index;
+        // TradingView halts the script with a runtime error on out-of-bounds access.
+        if (resolved < 0 || resolved >= id.array.length) {
+            throw new PineRuntimeError(
                 `Index ${index} is out of bounds, array size is ${id.array.length}.`,
                 'array.set'
             );
-            return;
         }
-        id.array[index] = typeof value === 'number' ? context.precision(value) : value;
+        id.array[resolved] = typeof value === 'number' ? context.precision(value) : value;
     };
 }

--- a/src/namespaces/matrix/methods/col.ts
+++ b/src/namespaces/matrix/methods/col.ts
@@ -4,18 +4,18 @@ import { PineMatrixObject } from '../PineMatrixObject';
 import { Context } from '../../../Context.class';
 import { PineArrayObject } from '../../array/PineArrayObject';
 import { inferValueType } from '@pinets/namespaces/array/utils';
+import { PineRuntimeError } from '../../../errors/PineRuntimeError';
 
 export function col(context: Context) {
     return (id: PineMatrixObject, column: number) => {
         const rows = id.matrix.length;
         const cols = rows > 0 ? id.matrix[0].length : 0;
+        // TradingView halts the script with a runtime error on out-of-bounds access.
         if (column < 0 || column >= cols) {
-            context.warn(
+            throw new PineRuntimeError(
                 `Column index ${column} is out of bounds, matrix has ${cols} columns.`,
                 'matrix.col'
             );
-            const anyType = rows > 0 ? inferValueType(id.matrix[0][0]) : 'float';
-            return new PineArrayObject([], anyType as any, context);
         }
         const result = [];
         for (let i = 0; i < rows; i++) {

--- a/src/namespaces/matrix/methods/get.ts
+++ b/src/namespaces/matrix/methods/get.ts
@@ -2,24 +2,24 @@
 
 import { PineMatrixObject } from '../PineMatrixObject';
 import { Context } from '../../../Context.class';
+import { PineRuntimeError } from '../../../errors/PineRuntimeError';
 
 export function get(context: Context) {
     return (id: PineMatrixObject, row: number, col: number) => {
         const rows = id.matrix.length;
         const cols = rows > 0 ? id.matrix[0].length : 0;
+        // TradingView halts the script with a runtime error on out-of-bounds access.
         if (row < 0 || row >= rows) {
-            context.warn(
+            throw new PineRuntimeError(
                 `Row index ${row} is out of bounds, matrix has ${rows} rows.`,
                 'matrix.get'
             );
-            return NaN;
         }
         if (col < 0 || col >= cols) {
-            context.warn(
+            throw new PineRuntimeError(
                 `Column index ${col} is out of bounds, matrix has ${cols} columns.`,
                 'matrix.get'
             );
-            return NaN;
         }
         const val = id.matrix[row][col];
         return val === undefined ? NaN : val;

--- a/src/namespaces/matrix/methods/row.ts
+++ b/src/namespaces/matrix/methods/row.ts
@@ -4,17 +4,17 @@ import { PineMatrixObject } from '../PineMatrixObject';
 import { Context } from '../../../Context.class';
 import { PineArrayObject } from '../../array/PineArrayObject';
 import { inferValueType } from '@pinets/namespaces/array/utils';
+import { PineRuntimeError } from '../../../errors/PineRuntimeError';
 
 export function row(context: Context) {
     return (id: PineMatrixObject, row: number) => {
         const rows = id.matrix.length;
+        // TradingView halts the script with a runtime error on out-of-bounds access.
         if (row < 0 || row >= rows) {
-            context.warn(
+            throw new PineRuntimeError(
                 `Row index ${row} is out of bounds, matrix has ${rows} rows.`,
                 'matrix.row'
             );
-            const anyType = rows > 0 ? inferValueType(id.matrix[0][0]) : 'float';
-            return new PineArrayObject([], anyType as any, context);
         }
         const rowType = inferValueType(id.matrix[row][0]);
         return new PineArrayObject([...id.matrix[row]], rowType as any, context);

--- a/src/namespaces/matrix/methods/set.ts
+++ b/src/namespaces/matrix/methods/set.ts
@@ -2,24 +2,24 @@
 
 import { PineMatrixObject } from '../PineMatrixObject';
 import { Context } from '../../../Context.class';
+import { PineRuntimeError } from '../../../errors/PineRuntimeError';
 
 export function set(context: Context) {
     return (id: PineMatrixObject, row: number, col: number, value: any) => {
         const rows = id.matrix.length;
         const cols = rows > 0 ? id.matrix[0].length : 0;
+        // TradingView halts the script with a runtime error on out-of-bounds access.
         if (row < 0 || row >= rows) {
-            context.warn(
+            throw new PineRuntimeError(
                 `Row index ${row} is out of bounds, matrix has ${rows} rows.`,
                 'matrix.set'
             );
-            return;
         }
         if (col < 0 || col >= cols) {
-            context.warn(
+            throw new PineRuntimeError(
                 `Column index ${col} is out of bounds, matrix has ${cols} columns.`,
                 'matrix.set'
             );
-            return;
         }
         id.matrix[row][col] = value;
     };

--- a/tests/namespaces/array/bounds-check.test.ts
+++ b/tests/namespaces/array/bounds-check.test.ts
@@ -4,13 +4,15 @@
 /**
  * Array.get Bounds Checking Tests
  *
- * Tests that out-of-bounds array access emits a warning and returns na (NaN),
- * allowing the script to continue execution (non-blocking).
+ * Tests that out-of-bounds array access halts the script with a
+ * PineRuntimeError (TradingView parity), while valid indices —
+ * including v6 negative indices — return the correct values.
  */
 
 import { describe, it, expect } from 'vitest';
 import PineTS from '../../../src/PineTS.class';
 import { Provider } from '../../../src/marketData/Provider.class';
+import { PineRuntimeError } from '../../../src/errors/PineRuntimeError';
 
 describe('Array.get Bounds Checking', () => {
     const sDate = new Date('2024-01-01').getTime();
@@ -36,50 +38,34 @@ describe('Array.get Bounds Checking', () => {
         expect(last(result.val2)).toBe(100);  // -3 -> first element
     });
 
-    it('should return NaN and emit warning for negative index beyond bounds', async () => {
+    it('should throw PineRuntimeError for negative index beyond bounds', async () => {
         const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', '1h', null, sDate, eDate);
 
         const sourceCode = (context: any) => {
-            const { array, na } = context.pine;
+            const { array } = context.pine;
 
             const arr = array.new_float(3, 100);
             const oob = array.get(arr, -4);    // out of bounds (beyond first)
-            const isNa = na(oob);
 
-            return { oob, isNa };
+            return { oob };
         };
 
-        const ctx = await pineTS.run(sourceCode);
-        const last = (arr: any[]) => arr[arr.length - 1];
-
-        expect(last(ctx.result.oob)).toBeNaN();
-        expect(last(ctx.result.isNa)).toBe(true);
-        expect(ctx.warnings.length).toBeGreaterThan(0);
-        expect(ctx.warnings[0].method).toBe('array.get');
+        await expect(pineTS.run(sourceCode)).rejects.toThrow(PineRuntimeError);
     });
 
-    it('should return NaN and emit warning for index >= array length', async () => {
+    it('should throw PineRuntimeError for index >= array length', async () => {
         const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', '1h', null, sDate, eDate);
 
         const sourceCode = (context: any) => {
-            const { array, na } = context.pine;
+            const { array } = context.pine;
 
             const arr = array.new_float(3, 100);
             const val_at_length = array.get(arr, 3);    // index == length
-            const val_beyond = array.get(arr, 10);       // index > length
-            const isNa1 = na(val_at_length);
-            const isNa2 = na(val_beyond);
 
-            return { val_at_length, val_beyond, isNa1, isNa2 };
+            return { val_at_length };
         };
 
-        const ctx = await pineTS.run(sourceCode);
-        const last = (arr: any[]) => arr[arr.length - 1];
-
-        expect(last(ctx.result.val_at_length)).toBeNaN();
-        expect(last(ctx.result.val_beyond)).toBeNaN();
-        expect(last(ctx.result.isNa1)).toBe(true);
-        expect(last(ctx.result.isNa2)).toBe(true);
+        await expect(pineTS.run(sourceCode)).rejects.toThrow(/out of bounds/);
     });
 
     it('should return correct value for valid index', async () => {
@@ -108,28 +94,22 @@ describe('Array.get Bounds Checking', () => {
         expect(last(result.last_val)).toBe(30);
     });
 
-    it('should return NaN and emit warning for empty array access', async () => {
+    it('should throw PineRuntimeError for empty array access', async () => {
         const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', '1h', null, sDate, eDate);
 
         const sourceCode = (context: any) => {
-            const { array, na } = context.pine;
+            const { array } = context.pine;
 
             const arr = array.new_float(0);
             const val = array.get(arr, 0);
-            const isNa = na(val);
 
-            return { val, isNa };
+            return { val };
         };
 
-        const ctx = await pineTS.run(sourceCode);
-        const last = (arr: any[]) => arr[arr.length - 1];
-
-        expect(last(ctx.result.val)).toBeNaN();
-        expect(last(ctx.result.isNa)).toBe(true);
-        expect(ctx.warnings.length).toBeGreaterThan(0);
+        await expect(pineTS.run(sourceCode)).rejects.toThrow(/out of bounds/);
     });
 
-    it('should include method name in warning', async () => {
+    it('should include method name and index in the runtime error', async () => {
         const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', '1h', null, sDate, eDate);
 
         const sourceCode = (context: any) => {
@@ -138,9 +118,16 @@ describe('Array.get Bounds Checking', () => {
             array.get(arr, 5);
         };
 
-        const ctx = await pineTS.run(sourceCode);
-        expect(ctx.warnings.length).toBeGreaterThan(0);
-        expect(ctx.warnings[0].method).toBe('array.get');
-        expect(ctx.warnings[0].message).toContain('out of bounds');
+        let caught: unknown;
+        try {
+            await pineTS.run(sourceCode);
+        } catch (err) {
+            caught = err;
+        }
+
+        expect(caught).toBeInstanceOf(PineRuntimeError);
+        expect((caught as PineRuntimeError).method).toBe('array.get');
+        expect((caught as PineRuntimeError).message).toContain('Index 5 is out of bounds');
+        expect((caught as PineRuntimeError).message).toContain('array size is 3');
     });
 });

--- a/tests/namespaces/array/negative-index.test.ts
+++ b/tests/namespaces/array/negative-index.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../../src/PineTS.class';
 import { Provider } from '@pinets/marketData/Provider.class';
+import { PineRuntimeError } from '../../../src/errors/PineRuntimeError';
 
 describe('Array Negative Index (v6 semantics)', () => {
     const startDate = new Date('2024-01-01').getTime();
@@ -56,30 +57,26 @@ describe('Array Negative Index (v6 semantics)', () => {
             expect(plots['neg4'].data[0].value).toBe(20);
         });
 
-        it('should return NaN and warn for negative index beyond bounds', async () => {
+        it('should throw PineRuntimeError for negative index beyond bounds', async () => {
             const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, startDate, endDate);
             const code = `
-                const { array, na, plotchar } = context.pine;
+                const { array, plotchar } = context.pine;
                 let a = array.from(10, 20, 30);
                 let oob = array.get(a, -4);
-                plotchar(na(oob) ? 1 : 0, 'isNa');
+                plotchar(oob, 'oob');
             `;
-            const ctx = await pineTS.run(code);
-            expect(ctx.plots['isNa'].data[0].value).toBe(1);
-            expect(ctx.warnings.length).toBeGreaterThan(0);
+            await expect(pineTS.run(code)).rejects.toThrow(PineRuntimeError);
         });
 
-        it('should return NaN and warn for negative index on empty array', async () => {
+        it('should throw PineRuntimeError for negative index on empty array', async () => {
             const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, startDate, endDate);
             const code = `
-                const { array, na, plotchar } = context.pine;
+                const { array, plotchar } = context.pine;
                 let a = array.new_float(0);
                 let val = array.get(a, -1);
-                plotchar(na(val) ? 1 : 0, 'isNa');
+                plotchar(val, 'val');
             `;
-            const ctx = await pineTS.run(code);
-            expect(ctx.plots['isNa'].data[0].value).toBe(1);
-            expect(ctx.warnings.length).toBeGreaterThan(0);
+            await expect(pineTS.run(code)).rejects.toThrow(/out of bounds/);
         });
 
         it('should work with method syntax (a.get(-1))', async () => {
@@ -104,16 +101,15 @@ describe('Array Negative Index (v6 semantics)', () => {
             expect(plots['neg1'].data[0].value).toBe(42);
         });
 
-        it('should return NaN and warn for OOB on single-element array', async () => {
+        it('should throw PineRuntimeError for OOB on single-element array', async () => {
             const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, startDate, endDate);
             const code = `
-                const { array, na, plotchar } = context.pine;
+                const { array, plotchar } = context.pine;
                 let a = array.from(42);
                 let oob = array.get(a, -2);
-                plotchar(na(oob) ? 1 : 0, 'oobNa');
+                plotchar(oob, 'oob');
             `;
-            const ctx = await pineTS.run(code);
-            expect(ctx.plots['oobNa'].data[0].value).toBe(1);
+            await expect(pineTS.run(code)).rejects.toThrow(PineRuntimeError);
         });
     });
 
@@ -144,19 +140,15 @@ describe('Array Negative Index (v6 semantics)', () => {
             expect(plots['val'].data[0].value).toBe(77);
         });
 
-        it('should warn for out-of-bounds negative index (no-op)', async () => {
+        it('should throw PineRuntimeError for out-of-bounds negative index', async () => {
             const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, startDate, endDate);
             const code = `
                 const { array, plotchar } = context.pine;
                 let a = array.from(1, 2, 3);
                 array.set(a, -4, 99);
                 plotchar(array.get(a, 0), 'v0');
-                plotchar(array.size(a), 'size');
             `;
-            const ctx = await pineTS.run(code);
-            expect(ctx.plots['v0'].data[0].value).toBe(1);  // unchanged
-            expect(ctx.plots['size'].data[0].value).toBe(3); // unchanged
-            expect(ctx.warnings.some((w: any) => w.method === 'array.set')).toBe(true);
+            await expect(pineTS.run(code)).rejects.toThrow(PineRuntimeError);
         });
     });
 
@@ -195,19 +187,15 @@ describe('Array Negative Index (v6 semantics)', () => {
             expect(plots['first'].data[0].value).toBe(20);
         });
 
-        it('should warn for out-of-bounds negative index remove', async () => {
+        it('should throw PineRuntimeError for out-of-bounds negative index remove', async () => {
             const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, startDate, endDate);
             const code = `
-                const { array, na, plotchar } = context.pine;
+                const { array, plotchar } = context.pine;
                 let a = array.from(10, 20, 30);
                 let removed = array.remove(a, -4);
-                plotchar(na(removed) ? 1 : 0, 'isNa');
-                plotchar(array.size(a), 'size');
+                plotchar(removed, 'removed');
             `;
-            const ctx = await pineTS.run(code);
-            expect(ctx.plots['isNa'].data[0].value).toBe(1);
-            expect(ctx.plots['size'].data[0].value).toBe(3); // unchanged
-            expect(ctx.warnings.some((w: any) => w.method === 'array.remove')).toBe(true);
+            await expect(pineTS.run(code)).rejects.toThrow(PineRuntimeError);
         });
     });
 

--- a/tests/namespaces/array/oob-runtime-error.test.ts
+++ b/tests/namespaces/array/oob-runtime-error.test.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Out-of-Bounds Runtime Error Tests (TradingView parity)
+ *
+ * TradingView halts the script with a runtime error on out-of-bounds
+ * array/matrix access ("Index xx is out of bounds. Array size is yy",
+ * see https://www.tradingview.com/pine-script-docs/v4/essential/arrays/).
+ * PineTS must throw a catchable PineRuntimeError, not warn-and-continue.
+ *
+ * Regression guard for: empty array + a.get(2) silently returned na.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PineTS } from '../../../src/PineTS.class';
+import { Provider } from '@pinets/marketData/Provider.class';
+import { PineRuntimeError } from '../../../src/errors/PineRuntimeError';
+
+const startDate = new Date('2024-01-01').getTime();
+const endDate = new Date('2024-01-03').getTime();
+
+function newPineTS() {
+    return new PineTS(Provider.Mock, 'BTCUSDC', '60', null, startDate, endDate);
+}
+
+describe('Out-of-bounds access throws PineRuntimeError (TV parity)', () => {
+    it('array.get on an empty array halts the script (original report)', async () => {
+        const script = `
+//@version=6
+indicator("Ask Aggression Oscillator", "AAO", overlay = false, precision = 2, max_bars_back = 500)
+
+a = array.new<float>(0)
+b = a.get(2)
+plot(b)
+`;
+        let caught: unknown;
+        try {
+            await newPineTS().run(script);
+        } catch (err) {
+            caught = err;
+        }
+
+        expect(caught).toBeInstanceOf(PineRuntimeError);
+        expect((caught as PineRuntimeError).method).toBe('array.get');
+        expect((caught as PineRuntimeError).message).toContain('Index 2 is out of bounds');
+        expect((caught as PineRuntimeError).message).toContain('size is 0');
+    });
+
+    it('array.get with index >= size throws', async () => {
+        const code = (context: any) => {
+            const { array } = context.pine;
+            const arr = array.new_float(3, 100);
+            return array.get(arr, 3);
+        };
+        await expect(newPineTS().run(code)).rejects.toThrow(PineRuntimeError);
+    });
+
+    it('array.get with negative index beyond -size throws', async () => {
+        const code = (context: any) => {
+            const { array } = context.pine;
+            const arr = array.new_float(3, 100);
+            return array.get(arr, -4);
+        };
+        await expect(newPineTS().run(code)).rejects.toThrow(PineRuntimeError);
+    });
+
+    it('array.set out of bounds throws', async () => {
+        const code = (context: any) => {
+            const { array } = context.pine;
+            const arr = array.new_float(3, 100);
+            array.set(arr, 5, 42);
+        };
+        await expect(newPineTS().run(code)).rejects.toThrow(PineRuntimeError);
+    });
+
+    it('array.insert beyond size throws', async () => {
+        const code = (context: any) => {
+            const { array } = context.pine;
+            const arr = array.new_float(3, 100);
+            array.insert(arr, 5, 42);
+        };
+        await expect(newPineTS().run(code)).rejects.toThrow(PineRuntimeError);
+    });
+
+    it('array.remove out of bounds throws', async () => {
+        const code = (context: any) => {
+            const { array } = context.pine;
+            const arr = array.new_float(3, 100);
+            return array.remove(arr, 5);
+        };
+        await expect(newPineTS().run(code)).rejects.toThrow(PineRuntimeError);
+    });
+
+    it('matrix.get out of bounds throws', async () => {
+        const code = (context: any) => {
+            const { matrix } = context.pine;
+            const m = matrix.new(3, 3, 0);
+            return matrix.get(m, 5, 0);
+        };
+        await expect(newPineTS().run(code)).rejects.toThrow(PineRuntimeError);
+    });
+
+    it('matrix.set out of bounds throws', async () => {
+        const code = (context: any) => {
+            const { matrix } = context.pine;
+            const m = matrix.new(3, 3, 0);
+            matrix.set(m, 0, 5, 1);
+        };
+        await expect(newPineTS().run(code)).rejects.toThrow(PineRuntimeError);
+    });
+
+    it('matrix.row / matrix.col out of bounds throw', async () => {
+        const rowCode = (context: any) => {
+            const { matrix } = context.pine;
+            const m = matrix.new(3, 3, 0);
+            return matrix.row(m, 5);
+        };
+        const colCode = (context: any) => {
+            const { matrix } = context.pine;
+            const m = matrix.new(3, 3, 0);
+            return matrix.col(m, 5);
+        };
+        await expect(newPineTS().run(rowCode)).rejects.toThrow(PineRuntimeError);
+        await expect(newPineTS().run(colCode)).rejects.toThrow(PineRuntimeError);
+    });
+
+    it('valid access still works (no throw)', async () => {
+        const code = (context: any) => {
+            const { array, matrix } = context.pine;
+            const arr = array.new_float(3, 100);
+            const mat = matrix.new(2, 2, 7);
+            const a = array.get(arr, 2);
+            const neg = array.get(arr, -1);
+            const m = matrix.get(mat, 1, 1);
+            return { a, neg, m };
+        };
+        const { result } = await newPineTS().run(code);
+        const last = (arr: any[]) => arr[arr.length - 1];
+        expect(last(result.a)).toBe(100);
+        expect(last(result.neg)).toBe(100);
+        expect(last(result.m)).toBe(7);
+    });
+});

--- a/tests/namespaces/array/runtime-error-capture.test.ts
+++ b/tests/namespaces/array/runtime-error-capture.test.ts
@@ -1,27 +1,29 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * Runtime Warning / Error Capture Tests
+ * Runtime Error Capture Tests
  *
  * Verifies that:
- * - Array/matrix OOB emits non-blocking warnings (script continues, returns na)
- * - Warnings are accessible via context.warnings after run()
- * - Warnings are emitted via 'warning' event in stream()
+ * - Array/matrix OOB access halts the script with a PineRuntimeError
+ *   (TradingView parity — "Index xx is out of bounds, array size is yy")
+ * - The error is catchable and carries the offending method name
+ * - stream() emits an 'error' event on OOB access
  * - Loop guard violations still throw (blocking errors)
  */
 
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../../src/PineTS.class';
 import { Provider } from '@pinets/marketData/Provider.class';
+import { PineRuntimeError } from '../../../src/errors/PineRuntimeError';
 
-describe('Runtime Warning / Error Capture', () => {
+describe('Runtime Error Capture', () => {
     const startDate = new Date('2024-01-01').getTime();
     const endDate = new Date('2024-01-05').getTime();
 
-    // -- run() API: warnings --
+    // -- run() API: OOB errors --
 
-    describe('run() API - OOB warnings', () => {
-        it('array.get OOB emits warning and returns na', async () => {
+    describe('run() API - OOB runtime errors', () => {
+        it('array.get OOB throws PineRuntimeError', async () => {
             const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, startDate, endDate);
             const code = (context: any) => {
                 const { array } = context.pine;
@@ -29,30 +31,31 @@ describe('Runtime Warning / Error Capture', () => {
                 return array.get(arr, 10);
             };
 
-            const ctx = await pineTS.run(code);
-            // Script continues — result is NaN (na)
-            expect(ctx.result[0]).toBeNaN();
-            // Warning is captured
-            expect(ctx.warnings.length).toBeGreaterThan(0);
-            expect(ctx.warnings[0].method).toBe('array.get');
-            expect(ctx.warnings[0].message).toContain('out of bounds');
+            let caught: unknown;
+            try {
+                await pineTS.run(code);
+            } catch (err) {
+                caught = err;
+            }
+
+            expect(caught).toBeInstanceOf(PineRuntimeError);
+            expect((caught as PineRuntimeError).method).toBe('array.get');
+            expect((caught as PineRuntimeError).message).toContain('out of bounds');
         });
 
-        it('array.set OOB emits warning (no-op)', async () => {
+        it('array.set OOB throws PineRuntimeError', async () => {
             const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, startDate, endDate);
             const code = (context: any) => {
                 const { array } = context.pine;
                 const arr = array.new_float(3, 100);
                 array.set(arr, 5, 42);
-                return array.get(arr, 0); // original value unchanged
+                return array.get(arr, 0);
             };
 
-            const ctx = await pineTS.run(code);
-            expect(ctx.result[0]).toBe(100);
-            expect(ctx.warnings.some((w: any) => w.method === 'array.set')).toBe(true);
+            await expect(pineTS.run(code)).rejects.toThrow(PineRuntimeError);
         });
 
-        it('array.remove OOB emits warning and returns na', async () => {
+        it('array.remove OOB throws PineRuntimeError', async () => {
             const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, startDate, endDate);
             const code = (context: any) => {
                 const { array } = context.pine;
@@ -60,12 +63,10 @@ describe('Runtime Warning / Error Capture', () => {
                 return array.remove(arr, 5);
             };
 
-            const ctx = await pineTS.run(code);
-            expect(ctx.result[0]).toBeNaN();
-            expect(ctx.warnings.some((w: any) => w.method === 'array.remove')).toBe(true);
+            await expect(pineTS.run(code)).rejects.toThrow(PineRuntimeError);
         });
 
-        it('matrix.get OOB emits warning and returns na', async () => {
+        it('matrix.get OOB throws PineRuntimeError', async () => {
             const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, startDate, endDate);
             const code = (context: any) => {
                 const { matrix } = context.pine;
@@ -73,9 +74,7 @@ describe('Runtime Warning / Error Capture', () => {
                 return matrix.get(m, 5, 0);
             };
 
-            const ctx = await pineTS.run(code);
-            expect(ctx.result[0]).toBeNaN();
-            expect(ctx.warnings.some((w: any) => w.method === 'matrix.get')).toBe(true);
+            await expect(pineTS.run(code)).rejects.toThrow(PineRuntimeError);
         });
 
         it('loop guard violation still throws (blocking)', async () => {
@@ -95,10 +94,10 @@ plot(i)
         });
     });
 
-    // -- stream() API: warning events --
+    // -- stream() API: error events --
 
-    describe('stream() API - warning events', () => {
-        it('emits warning event on array OOB', async () => {
+    describe('stream() API - error events', () => {
+        it('emits error event on array OOB', async () => {
             const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, startDate, endDate);
             await pineTS.ready();
             const code = (context: any) => {
@@ -107,32 +106,23 @@ plot(i)
                 array.get(arr, 10);
             };
 
-            const warnings: any[] = [];
-            let dataReceived = false;
-
-            await new Promise<void>((resolve, reject) => {
+            const error = await new Promise<any>((resolve, reject) => {
                 const stream = pineTS.stream(code, { live: false });
                 const timeout = setTimeout(() => reject(new Error('Timeout')), 5000);
 
-                stream.on('data', () => {
-                    dataReceived = true;
-                    clearTimeout(timeout);
-                    resolve();
-                });
-
-                stream.on('warning', (w: any) => {
-                    warnings.push(w);
-                });
-
                 stream.on('error', (err: any) => {
                     clearTimeout(timeout);
-                    reject(err);
+                    resolve(err);
+                });
+
+                stream.on('data', () => {
+                    clearTimeout(timeout);
+                    reject(new Error('Should not emit data'));
                 });
             });
 
-            expect(dataReceived).toBe(true); // Script continues despite OOB
-            expect(warnings.length).toBeGreaterThan(0);
-            expect(warnings[0].method).toBe('array.get');
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toContain('out of bounds');
         });
 
         it('loop guard still emits error event (blocking)', async () => {


### PR DESCRIPTION
## Summary

- Out-of-bounds `array.get/set/insert/remove` and `matrix.get/set/row/col` previously emitted a non-blocking `context.warn()` and returned `na`/no-op, so scripts like `a = array.new<float>(0)` + `a.get(2)` silently ran to completion. TradingView halts with a runtime error here ("Index xx is out of bounds. Array size is yy" — [Pine docs on arrays](https://www.tradingview.com/pine-script-docs/v4/essential/arrays/)).
- These eight methods now throw the catchable `PineRuntimeError` with `method` set to the offending call (e.g. `'array.get'`). Pine v6 negative-index normalization is unchanged, and the error reports the index the script passed (not the normalized one).
- `stream()` consumers now receive an `'error'` event instead of a `'warning'` for these violations.

## Tests

- New regression suite `tests/namespaces/array/oob-runtime-error.test.ts` (10 tests), including the originally reported script:

```pinescript
//@version=6
indicator("Ask Aggression Oscillator", "AAO", overlay = false, precision = 2, max_bars_back = 500)
a = array.new<float>(0)
b = a.get(2)
plot(b)
```

which now halts with `PineRuntimeError: Index 2 is out of bounds, array size is 0.` instead of plotting `na` with 49 warnings.

- Updated `bounds-check`, `negative-index` and `runtime-error-capture` tests to expect the throw (they previously locked in the warn-and-continue behavior).
- Full suite on this branch: 1837 passed, 0 failed.

## Test plan

- [ ] `npm test -- --run` passes
- [ ] Optional TV cross-check: run the selectable-case parity script (cases 1–10 must all raise a runtime error on TradingView; case 0 plots 67)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking behavior for scripts and integrations that relied on warn-and-continue OOB handling; streaming clients must listen on `error` instead of `warning` for these violations.
> 
> **Overview**
> **Out-of-bounds array and matrix access now halts the script** instead of emitting a non-blocking warning and returning `na` or no-op. This matches TradingView: invalid indices on `array.get` / `set` / `insert` / `remove` and `matrix.get` / `set` / `row` / `col` throw **`PineRuntimeError`** with the offending `method` and a message that uses the **script-supplied index** (v6 negative-index resolution is unchanged).
> 
> **Streaming behavior changes:** `stream()` listeners should use **`error`** for these cases, not **`warning`**. Docs drop the array-OOB-specific warning examples.
> 
> Tests are updated to expect throws, plus a new **`oob-runtime-error`** regression suite (including empty `array.new<float>(0)` + `a.get(2)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 340699cc2c53f95654d27aa23673460efedb8bb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->