### PR TITLE
Fix calendar builtins history access: hour[1], dayofweek[1], ... never looked back

### DIFF
--- a/src/namespaces/Time.ts
+++ b/src/namespaces/Time.ts
@@ -312,25 +312,49 @@ const TIME_COMPONENT_ARGS_TYPES = {
  * Single parameterized class for all 8 dual-use time component identifiers:
  * dayofmonth, dayofweek, hour, minute, month, second, weekofyear, year.
  *
- * - Bare `dayofmonth` → `dayofmonth.__value` → extract from current bar openTime
+ * - Bare `dayofmonth` → `$.get(dayofmonth.__value, 0)` → current bar's value
+ * - `dayofmonth[1]` → `$.get(dayofmonth.__value, 1)` → previous bar's value
  * - `dayofmonth(time)` → extract from given timestamp
  * - `dayofmonth(time, timezone)` → extract from timestamp in given timezone
+ *
+ * `__value` MUST be a Series (same shape as TimeHelper.__value): these
+ * identifiers are series in Pine, so history indexing has to reach previous
+ * bars. A scalar here would make `$.get(hour.__value, 1)` ignore the offset
+ * and `param(...)` fall into its one-element scalar buffer — `hour[1]` would
+ * be na on every bar and `hour != hour[1]` would never fire.
  */
 export class TimeComponentHelper {
     private context: any;
     private extractor: (parts: DateParts) => number;
+
+    /** Extracted component per bar, kept in lockstep with data.openTime. */
+    private _cache: number[] = [];
+    private _cacheTimezone: string | null = null;
 
     constructor(context: any, extractor: (parts: DateParts) => number) {
         this.context = context;
         this.extractor = extractor;
     }
 
-    get __value() {
-        const currentTime = Series.from(this.context.data.openTime).get(0);
-        if (isNaN(currentTime)) return NaN;
+    get __value(): Series {
+        const openTime = this.context.data.openTime;
+        const times: any[] = openTime instanceof Series ? openTime.data : Array.isArray(openTime) ? openTime : [];
         const timezone = this.context.pine?.syminfo?.timezone || 'UTC';
-        const parts = getDatePartsInTimezone(currentTime, timezone);
-        return this.extractor(parts);
+
+        if (timezone !== this._cacheTimezone) {
+            this._cache = [];
+            this._cacheTimezone = timezone;
+        }
+        const cache = this._cache;
+        // Streaming updates pop bars off openTime before re-pushing them;
+        // truncate so re-processed bars are re-extracted.
+        if (cache.length > times.length) cache.length = times.length;
+        for (let i = cache.length; i < times.length; i++) {
+            const t = times[i];
+            cache.push(t == null || isNaN(t) ? NaN : this.extractor(getDatePartsInTimezone(t, timezone)));
+        }
+
+        return new Series(cache, openTime instanceof Series ? openTime.offset : 0);
     }
 
     param(source: any, index: number = 0) {
@@ -340,9 +364,9 @@ export class TimeComponentHelper {
     any(...args: any[]) {
         const unwrapped = args.map((a) => (a instanceof Series ? a.get(0) : a));
 
-        // No args → same as bare identifier
+        // No args → same as bare identifier (current bar's value)
         if (unwrapped.length === 0) {
-            return this.__value;
+            return this.__value.get(0);
         }
 
         const parsed = parseArgsForPineParams<any>(unwrapped, TIME_COMPONENT_SIGNATURES, TIME_COMPONENT_ARGS_TYPES);

--- a/tests/core/time-components-history.test.ts
+++ b/tests/core/time-components-history.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import { PineTS } from '../../src/PineTS.class';
+import { Provider } from '../../src/marketData/Provider.class';
+
+// Regression guard: calendar builtins (hour, dayofweek, month, ...) are SERIES.
+// History indexing (`hour[1]`, `dayofweek[1]`) must return the previous bar's
+// value, exactly like `time[1]`. Before the fix, TimeComponentHelper.__value
+// was a scalar, so `x[1]` was na on every bar and `x != x[1]` never fired.
+//
+// Expected values are derived independently from the bar openTime timestamps
+// via JS Date UTC accessors (Mock provider data is UTC-aligned) — never from
+// PineTS component output itself.
+
+// Hourly bars across a UTC midnight boundary: 2024-01-01 (Monday) → 2024-01-03
+const pineTS = new PineTS(
+    Provider.Mock,
+    'BTCUSDC',
+    '60',
+    null,
+    new Date('2024-01-01T00:00:00Z').getTime(),
+    new Date('2024-01-03T00:00:00Z').getTime(),
+);
+
+// Pine dayofweek: Sun=1 .. Sat=7 (JS getUTCDay: Sun=0 .. Sat=6)
+const pineDow = (t: number) => new Date(t).getUTCDay() + 1;
+
+describe('time component history access (hour[1], dayofweek[1], ...)', () => {
+    it('hour[1] equals previous bar hour, na on bar 0 only', async () => {
+        const { result } = await pineTS.run(($) => {
+            const { time, hour } = $.pine;
+            let t = time;
+            let h = hour;
+            let h1 = hour[1];
+            return { t, h, h1 };
+        });
+
+        expect(result.t.length).toBeGreaterThan(24);
+        expect(result.h1[0]).toBeNaN();
+        for (let i = 0; i < result.t.length; i++) {
+            const expected = new Date(result.t[i]).getUTCHours();
+            expect(result.h[i]).toBe(expected);
+            if (i > 0) {
+                const expectedPrev = new Date(result.t[i - 1]).getUTCHours();
+                expect(result.h1[i]).toBe(expectedPrev);
+            }
+        }
+    });
+
+    it('hour != hour[1] is true on every bar after the first (hourly bars)', async () => {
+        const { result } = await pineTS.run(($) => {
+            const { hour } = $.pine;
+            let changed = hour != hour[1] ? 1 : 0;
+            return { changed };
+        });
+
+        // Bar 0: hour[1] is na → comparison is na → falsy
+        expect(result.changed[0]).toBe(0);
+        for (let i = 1; i < result.changed.length; i++) {
+            expect(result.changed[i]).toBe(1);
+        }
+    });
+
+    it('dayofweek[1] equals previous bar dayofweek', async () => {
+        const { result } = await pineTS.run(($) => {
+            const { time, dayofweek } = $.pine;
+            let t = time;
+            let d1 = dayofweek[1];
+            return { t, d1 };
+        });
+
+        expect(result.d1[0]).toBeNaN();
+        for (let i = 1; i < result.t.length; i++) {
+            expect(result.d1[i]).toBe(pineDow(result.t[i - 1]));
+        }
+    });
+
+    it('dayofweek != dayofweek[1] fires only on the first bar of a new weekday', async () => {
+        const { result } = await pineTS.run(($) => {
+            const { time, dayofweek } = $.pine;
+            let t = time;
+            let dayChanged = dayofweek != dayofweek[1] ? 1 : 0;
+            return { t, dayChanged };
+        });
+
+        expect(result.dayChanged[0]).toBe(0); // na comparison on bar 0
+        let fired = 0;
+        for (let i = 1; i < result.t.length; i++) {
+            const expected = pineDow(result.t[i]) !== pineDow(result.t[i - 1]) ? 1 : 0;
+            expect(result.dayChanged[i]).toBe(expected);
+            fired += result.dayChanged[i];
+        }
+        // The range spans at least one UTC midnight → at least one day change
+        expect(fired).toBeGreaterThan(0);
+    });
+
+    it('day-change detection works in native Pine Script (LuxAlgo Sessions pattern)', async () => {
+        const code = `
+//@version=5
+indicator("Day Change")
+bool dayChanged = dayofweek != dayofweek[1]
+plot(dayChanged ? 1 : 0, "dc")
+plot(time, "t")
+`;
+        const { plots } = await pineTS.run(code);
+        const dc = plots['dc'].data;
+        const t = plots['t'].data;
+
+        expect(dc[0].value).toBe(0);
+        for (let i = 1; i < dc.length; i++) {
+            const expected = pineDow(t[i].value) !== pineDow(t[i - 1].value) ? 1 : 0;
+            expect(dc[i].value).toBe(expected);
+        }
+    });
+
+    it('ta.change(hour) still works', async () => {
+        const { result } = await pineTS.run(($) => {
+            const { hour } = $.pine;
+            const { ta } = $.pine;
+            let c = ta.change(hour);
+            return { c };
+        });
+
+        // On hourly bars, hour changes by 1 every bar (or -23 at midnight)
+        for (let i = 1; i < result.c.length; i++) {
+            expect(result.c[i] === 1 || result.c[i] === -23).toBe(true);
+        }
+    });
+
+    it('dayofweek enum constants and function form still work', async () => {
+        const { result } = await pineTS.run(($) => {
+            const { dayofweek } = $.pine;
+            let mon = dayofweek.monday;
+            // 2024-01-01 00:00 UTC is a Monday; in New York it's still Sunday evening
+            let dNY = dayofweek(1704067200000, 'America/New_York');
+            return { mon, dNY };
+        });
+
+        expect(result.mon[0]).toBe(2);
+        expect(result.dNY[0]).toBe(1); // Sunday in New York
+    });
+});
+
+describe('time component history on daily bars (month/year/dayofmonth)', () => {
+    // Daily bars across a year boundary: 2024-12-28 → 2025-01-05
+    // (Mock daily data starts at 2024-01-01, so use the 2024→2025 boundary)
+    const daily = new PineTS(
+        Provider.Mock,
+        'BTCUSDC',
+        'D',
+        null,
+        new Date('2024-12-28T00:00:00Z').getTime(),
+        new Date('2025-01-05T00:00:00Z').getTime(),
+    );
+
+    it('month[1], year[1] and dayofmonth[1] return previous bar values', async () => {
+        const { result } = await daily.run(($) => {
+            const { time, month, year, dayofmonth } = $.pine;
+            let t = time;
+            let m1 = month[1];
+            let y1 = year[1];
+            let dom1 = dayofmonth[1];
+            return { t, m1, y1, dom1 };
+        });
+
+        expect(result.m1[0]).toBeNaN();
+        expect(result.y1[0]).toBeNaN();
+        expect(result.dom1[0]).toBeNaN();
+        for (let i = 1; i < result.t.length; i++) {
+            const prev = new Date(result.t[i - 1]);
+            expect(result.m1[i]).toBe(prev.getUTCMonth() + 1);
+            expect(result.y1[i]).toBe(prev.getUTCFullYear());
+            expect(result.dom1[i]).toBe(prev.getUTCDate());
+        }
+    });
+
+    it('year != year[1] fires exactly once across the year boundary', async () => {
+        const { result } = await daily.run(($) => {
+            const { time, year } = $.pine;
+            let t = time;
+            let yearChanged = year != year[1] ? 1 : 0;
+            return { t, yearChanged };
+        });
+
+        // Sanity: the data must actually span two calendar years
+        expect(new Date(result.t[0]).getUTCFullYear()).toBe(2024);
+        expect(new Date(result.t[result.t.length - 1]).getUTCFullYear()).toBe(2025);
+
+        let fired = 0;
+        for (let i = 1; i < result.t.length; i++) {
+            fired += result.yearChanged[i];
+        }
+        expect(fired).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary

Calendar builtins (`dayofweek`, `dayofmonth`, `hour`, `minute`, `second`, `month`, `year`, `weekofyear`) were scalars, so history indexing never looked back: `$.get(hour.__value, 1)` hit the scalar path in `Context.get` (offset ignored) and `param(hour.__value, 1, id)` fell into its one-element buffer. As a result `plot(hour[1])` was `na` on every bar and `hour != hour[1]` / `dayofweek != dayofweek[1]` never fired (real-world hit: LuxAlgo Sessions daily dividers never rendered).

`TimeComponentHelper.__value` now returns a **Series** (same shape as `TimeHelper.__value` for `time` / `time_close`): one extracted component per bar, mirroring `context.data.openTime`'s offset.

- Internal cache extends incrementally (O(1) amortized per bar — matters because IANA timezones go through `Intl.DateTimeFormat`), truncates when streaming rollback pops bars, and resets on `syminfo.timezone` change.
- No transpiler / `Context` / `request.security` changes needed — every `__value` consumer already handles the Series shape.
- Unchanged behavior: bare `hour` (current value), `hour(time)` / `hour(time, timezone)` function form, `dayofweek.monday`-style constants, `ta.change(hour)`.

## Test plan

- [x] New regression guard `tests/core/time-components-history.test.ts`, written failing-first (7/9 assertions failed pre-fix). Expected values derived independently from bar `openTime` timestamps via JS `Date` UTC accessors, never from PineTS output.
  - `hour[1]` equals previous bar's hour, `na` on bar 0 only
  - `hour != hour[1]` true on every hourly bar after the first
  - `dayofweek != dayofweek[1]` fires only on the first bar of a new weekday, incl. native Pine Script (LuxAlgo Sessions pattern)
  - `month[1]` / `year[1]` / `dayofmonth[1]` on daily bars; `year != year[1]` fires exactly once across the 2024→2025 boundary
  - `ta.change(hour)`, `dayofweek.monday`, `dayofweek(time, "America/New_York")` still work
- [x] Full suite green: `npm test -- --run` → 1836 passed, 0 failed (169 files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Pine calendar builtin semantics and streaming cache behavior for all eight helpers, though scope is isolated to `TimeComponentHelper` with broad regression coverage.
> 
> **Overview**
> Calendar builtins (`hour`, `dayofweek`, `month`, etc.) now expose **`__value` as a per-bar `Series`** aligned with `openTime`, so history access like `hour[1]` and comparisons such as `dayofweek != dayofweek[1]` behave like Pine/`time[1]` instead of always yielding `na`.
> 
> **`TimeComponentHelper`** builds values incrementally via a bar cache (with truncate-on-streaming-rollback and reset on timezone change), and the no-arg function form still returns the **current bar** via `__value.get(0)`. Parameterized `hour(time)` / timezone forms are unchanged.
> 
> Adds **`tests/core/time-components-history.test.ts`** as a regression suite (history indexing, day/year change detection—including native Pine—and `ta.change(hour)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb3355ba7b68867390dd7a704c194d95d8bebdb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->