### PR TITLE
Fix na colors from color.from_gradient crashing array mutators

### DIFF
--- a/src/namespaces/array/utils.ts
+++ b/src/namespaces/array/utils.ts
@@ -54,7 +54,10 @@ export function isArrayOfType(array: any[], type: PineArrayType) {
 }
 
 export function isValueOfType(value: any, type: PineArrayType) {
-    // na (NaN) is compatible with all types in Pine Script
+    // na (NaN or undefined) is compatible with all types in Pine Script.
+    // Some namespace functions (e.g. color.from_gradient historically) may
+    // represent an na value as undefined, so treat it exactly like NaN.
+    if (value === undefined) return true;
     if (typeof value === 'number' && isNaN(value)) return true;
     // Untyped arrays (e.g. array.new<chart.point>()) accept any value
     if (type === PineArrayType.any) return true;

--- a/src/namespaces/color/PineColor.ts
+++ b/src/namespaces/color/PineColor.ts
@@ -226,13 +226,15 @@ export class PineColor {
         bottom_color = resolveColor(bottom_color);
         top_color = resolveColor(top_color);
 
-        // If any numeric arg is na (NaN/null/undefined), return na
-        if (value == null || (typeof value === 'number' && isNaN(value))) return undefined;
-        if (bottom_value == null || (typeof bottom_value === 'number' && isNaN(bottom_value))) return undefined;
-        if (top_value == null || (typeof top_value === 'number' && isNaN(top_value))) return undefined;
+        // If any numeric arg is na (NaN/null/undefined), return na.
+        // NaN is the runtime's na sentinel (see NAHelper.__value), so na colors
+        // keep a single consistent representation end-to-end.
+        if (value == null || (typeof value === 'number' && isNaN(value))) return NaN;
+        if (bottom_value == null || (typeof bottom_value === 'number' && isNaN(bottom_value))) return NaN;
+        if (top_value == null || (typeof top_value === 'number' && isNaN(top_value))) return NaN;
         // If either color is na, return na
-        if (bottom_color == null || (typeof bottom_color === 'number' && isNaN(bottom_color))) return undefined;
-        if (top_color == null || (typeof top_color === 'number' && isNaN(top_color))) return undefined;
+        if (bottom_color == null || (typeof bottom_color === 'number' && isNaN(bottom_color))) return NaN;
+        if (top_color == null || (typeof top_color === 'number' && isNaN(top_color))) return NaN;
 
         // Clamp position between 0 and 1
         let t = 0;

--- a/tests/namespaces/array/na-color-gradient.test.ts
+++ b/tests/namespaces/array/na-color-gradient.test.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Regression guard: na colors produced by color.from_gradient (optionally passed
+// through color.new) must be storable in color arrays via every mutator, and
+// color.from_gradient(na, ...) must compare equal to na.
+// See TradingView behavior: array.new_color(n, na) + array.set(arr, i, na-color) is legal.
+
+import { describe, expect, it } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+function newPineTS() {
+    return new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date('2024-01-01').getTime(), new Date('2024-01-10').getTime());
+}
+
+describe('na color from color.from_gradient stored in color arrays', () => {
+    it('Pine v6 repro: gradient na color through color.new into array.set', async () => {
+        const pineTS = newPineTS();
+
+        // EMA(200) is na on early bars → sc is NaN → gradient color is na.
+        const { plots } = await pineTS.run(`
+//@version=6
+indicator("repro gradient na")
+rowCols = array.new_color(2, na)
+val = ta.ema(close, 200)
+sc = (close - val)
+c = color.from_gradient(sc, 0, 1, color.red, color.green)
+array.set(rowCols, 0, color.new(c, 50))
+plot(na(array.get(rowCols, 0)) ? 1 : 0, "cellIsNa")
+        `);
+
+        const data = plots['cellIsNa'].data;
+        expect(data.length).toBeGreaterThan(0);
+        // On the first bar the EMA is na, so the stored cell must read back as na.
+        expect(data[0].value).toBe(1);
+        // On the last bars the EMA is valid, so a real color is stored.
+        expect(data[data.length - 1].value).toBe(0);
+    });
+
+    it('Pine v6 control: na literal into color array still works', async () => {
+        const pineTS = newPineTS();
+
+        const { plots } = await pineTS.run(`
+//@version=6
+indicator("repro na literal")
+rowCols = array.new_color(2, na)
+array.set(rowCols, 0, na)
+plot(na(array.get(rowCols, 0)) ? 1 : 0, "cellIsNa")
+        `);
+
+        const data = plots['cellIsNa'].data;
+        expect(data.length).toBeGreaterThan(0);
+        expect(data.every((p: any) => p.value === 1)).toBe(true);
+    });
+
+    it('all five mutators accept an na-derived color', async () => {
+        const pineTS = newPineTS();
+
+        const { result } = await pineTS.run(($) => {
+            const { close } = $.data;
+            const { ta, array, color, na } = $.pine;
+
+            const val = ta.ema(close, 200);
+            const sc = close - val;
+            const c = color.from_gradient(sc, 0, 1, color.red, color.green);
+            const c2 = color.new(c, 50);
+
+            const arrSet = array.new_color(2, na);
+            array.set(arrSet, 0, c2);
+
+            const arrFill = array.new_color(2, na);
+            array.fill(arrFill, c2);
+
+            const arrPush = array.new_color(0, na);
+            array.push(arrPush, c2);
+
+            const arrInsert = array.new_color(1, na);
+            array.insert(arrInsert, 0, c2);
+
+            const arrUnshift = array.new_color(1, na);
+            array.unshift(arrUnshift, c2);
+
+            const gradientIsNa = na(c);
+
+            return { gradientIsNa };
+        });
+
+        // First bar: EMA is na → gradient color must be na.
+        expect(result.gradientIsNa[0]).toBe(true);
+        // Last bar: EMA is valid → gradient color is a real color.
+        expect(result.gradientIsNa[result.gradientIsNa.length - 1]).toBe(false);
+    });
+
+    it('na literal in numeric arrays keeps working', async () => {
+        const pineTS = newPineTS();
+
+        const { result } = await pineTS.run(($) => {
+            const { array, na } = $.pine;
+
+            const arr = array.new_float(1);
+            array.set(arr, 0, na);
+            const cellIsNa = na(array.get(arr, 0));
+
+            return { cellIsNa };
+        });
+
+        expect(result.cellIsNa.every((v: boolean) => v === true)).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

- Fixes a runtime crash where na colors produced by `color.from_gradient` (optionally passed through `color.new`) could not be stored in color arrays: `array.set` threw `Cannot call 'array.set' with argument 'value'='undefined'. An argument of 'literal undefined' type was used but a 'color' is expected.` The same script runs without error on TradingView.
- `isValueOfType` (`src/namespaces/array/utils.ts`) now treats `undefined` as na — valid for every element type, exactly like `NaN`. Since all five mutators (`array.set`, `fill`, `push`, `insert`, `unshift`) share this validator, one change fixes them all.
- `color.from_gradient` (`src/namespaces/color/PineColor.ts`) now returns `NaN` (the runtime's na sentinel, per `NAHelper.__value`) instead of bare `undefined` from its na guards, so na colors keep a single consistent representation end-to-end. `color.new` needs no change: it already passes non-strings through unchanged, and `na()` recognizes `NaN`.

## Test plan

- [x] New regression test `tests/namespaces/array/na-color-gradient.test.ts` (deterministic Mock provider):
  - Pine v6 repro (gradient na color through `color.new` into `array.set`) runs without throwing; the cell reads back as na on early bars and holds a real color once the EMA is valid
  - Pine v6 control (na literal into a color array) still works
  - All five mutators accept an na-derived color; `na(color.from_gradient(na, ...))` is `true`
  - na literal in numeric arrays keeps working
- [x] Test verified to fail with the exact reported error before the fix, and pass after
- [x] Full suite passes: `npm test -- --run` (1850 passed, 0 failed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Pine runtime compatibility fix for na color representation and array validation; regression tests cover the reported paths.
> 
> **Overview**
> Fixes a runtime error when **na** colors from `color.from_gradient` (including after `color.new`) are written into color arrays—behavior that TradingView allows but PineTS rejected with a literal `undefined` type error.
> 
> **`color.from_gradient`** now returns **`NaN`** (the runtime na sentinel) instead of **`undefined`** when inputs are na, so na colors stay consistent with `na()` and the rest of the runtime.
> 
> **`isValueOfType`** in `array/utils.ts` treats **`undefined`** like **`NaN`** as valid na for any array element type, which unblocks all five shared mutators (`set`, `fill`, `push`, `insert`, `unshift`) without separate fixes.
> 
> Adds regression tests in `na-color-gradient.test.ts` for the Pine v6 repro, na literals, all mutators, and numeric-array na.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979dedb525873b83959cc8a590f088d968b9bffe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->