### PR TITLE
Add ta.max and ta.min (trailing maximum / minimum)

### DIFF
--- a/src/namespaces/ta/methods/max.ts
+++ b/src/namespaces/ta/methods/max.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { Series } from '../../../Series';
+
+/**
+ * Trailing Maximum (ta.max)
+ *
+ * Returns the all-time high value of `source` from the first bar of the
+ * chart up to the current bar.
+ *
+ * - `na` is returned until the first non-na `source` value is seen.
+ * - Later `na` values are ignored (the previous maximum is carried forward)
+ *   so a single missing value cannot poison the running result.
+ *
+ * State is committed per bar (keyed by `context.idx`) so re-evaluations of
+ * the still-forming live bar do not corrupt history.
+ *
+ * @param source - The series to track
+ * @returns The trailing maximum up to the current bar
+ */
+export function max(context: any) {
+    return (source: any, _callId?: string) => {
+        if (!context.taState) context.taState = {};
+        const stateKey = _callId || 'max';
+
+        if (!context.taState[stateKey]) {
+            context.taState[stateKey] = {
+                lastIdx: -1,
+                // Committed state (as of the previous bar)
+                prevMax: NaN,
+                // Tentative state (current bar, may be re-evaluated)
+                currentMax: NaN,
+            };
+        }
+
+        const state = context.taState[stateKey];
+
+        // Commit the previous bar's tentative value when moving to a new bar
+        if (context.idx > state.lastIdx) {
+            if (state.lastIdx >= 0) {
+                state.prevMax = state.currentMax;
+            }
+            state.lastIdx = context.idx;
+        }
+
+        const currentValue = Series.from(source).get(0);
+
+        let result: number;
+        if (isNaN(currentValue)) {
+            result = state.prevMax;
+        } else if (isNaN(state.prevMax)) {
+            result = currentValue;
+        } else {
+            result = Math.max(state.prevMax, currentValue);
+        }
+
+        state.currentMax = result;
+        return context.precision(result);
+    };
+}

--- a/src/namespaces/ta/methods/min.ts
+++ b/src/namespaces/ta/methods/min.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { Series } from '../../../Series';
+
+/**
+ * Trailing Minimum (ta.min)
+ *
+ * Returns the all-time low value of `source` from the first bar of the
+ * chart up to the current bar.
+ *
+ * - `na` is returned until the first non-na `source` value is seen.
+ * - Later `na` values are ignored (the previous minimum is carried forward)
+ *   so a single missing value cannot poison the running result.
+ *
+ * State is committed per bar (keyed by `context.idx`) so re-evaluations of
+ * the still-forming live bar do not corrupt history.
+ *
+ * @param source - The series to track
+ * @returns The trailing minimum up to the current bar
+ */
+export function min(context: any) {
+    return (source: any, _callId?: string) => {
+        if (!context.taState) context.taState = {};
+        const stateKey = _callId || 'min';
+
+        if (!context.taState[stateKey]) {
+            context.taState[stateKey] = {
+                lastIdx: -1,
+                // Committed state (as of the previous bar)
+                prevMin: NaN,
+                // Tentative state (current bar, may be re-evaluated)
+                currentMin: NaN,
+            };
+        }
+
+        const state = context.taState[stateKey];
+
+        // Commit the previous bar's tentative value when moving to a new bar
+        if (context.idx > state.lastIdx) {
+            if (state.lastIdx >= 0) {
+                state.prevMin = state.currentMin;
+            }
+            state.lastIdx = context.idx;
+        }
+
+        const currentValue = Series.from(source).get(0);
+
+        let result: number;
+        if (isNaN(currentValue)) {
+            result = state.prevMin;
+        } else if (isNaN(state.prevMin)) {
+            result = currentValue;
+        } else {
+            result = Math.min(state.prevMin, currentValue);
+        }
+
+        state.currentMin = result;
+        return context.precision(result);
+    };
+}

--- a/src/namespaces/ta/ta.index.ts
+++ b/src/namespaces/ta/ta.index.ts
@@ -33,8 +33,10 @@ import { linreg } from './methods/linreg';
 import { lowest } from './methods/lowest';
 import { lowestbars } from './methods/lowestbars';
 import { macd } from './methods/macd';
+import { max } from './methods/max';
 import { median } from './methods/median';
 import { mfi } from './methods/mfi';
+import { min } from './methods/min';
 import { mode } from './methods/mode';
 import { mom } from './methods/mom';
 import { nvi } from './methods/nvi';
@@ -103,8 +105,10 @@ const methods = {
   lowest,
   lowestbars,
   macd,
+  max,
   median,
   mfi,
+  min,
   mode,
   mom,
   nvi,
@@ -172,8 +176,10 @@ export class TechnicalAnalysis {
   lowest: ReturnType<typeof methods.lowest>;
   lowestbars: ReturnType<typeof methods.lowestbars>;
   macd: ReturnType<typeof methods.macd>;
+  max: ReturnType<typeof methods.max>;
   median: ReturnType<typeof methods.median>;
   mfi: ReturnType<typeof methods.mfi>;
+  min: ReturnType<typeof methods.min>;
   mode: ReturnType<typeof methods.mode>;
   mom: ReturnType<typeof methods.mom>;
   nvi: ReturnType<typeof methods.nvi>;

--- a/tests/namespaces/ta/trailing-max-min.test.ts
+++ b/tests/namespaces/ta/trailing-max-min.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { PineTS } from '../../../src/PineTS.class';
+import { Provider } from '../../../src/marketData/Provider.class';
+
+// ta.max(source) / ta.min(source): all-time (trailing) high / low of `source`
+// from the first bar of the chart up to the current bar.
+//
+// Expected values below are derived independently of the implementation:
+// either by hand from a synthetic step series, or by a plain JS running
+// max/min over the raw `close` series that the script also plots.
+
+function mk(from = '2024-01-01', to = '2024-01-05') {
+    return new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date(from).getTime(), new Date(to).getTime());
+}
+
+describe('ta.max / ta.min - trailing maximum / minimum', () => {
+    it('tracks a hand-built step series', async () => {
+        const { plots } = await mk().run(`//@version=5
+indicator("t")
+// 0,0,0,100,0,0,0,-50,0,0,...  -> max steps up at bar 3, min steps down at bar 7
+s = bar_index == 3 ? 100 : bar_index == 7 ? -50 : 0
+plot(ta.max(s), "mx")
+plot(ta.min(s), "mn")`);
+
+        const mx = plots['mx'].data.map((p) => p.value);
+        const mn = plots['mn'].data.map((p) => p.value);
+        expect(mx.length).toBeGreaterThan(10);
+
+        // Hand-derived expectations
+        expect(mx.slice(0, 3)).toEqual([0, 0, 0]);
+        expect(mx[3]).toBe(100);
+        expect(mx.slice(3).every((v) => v === 100)).toBe(true);
+
+        expect(mn.slice(0, 7)).toEqual([0, 0, 0, 0, 0, 0, 0]);
+        expect(mn[7]).toBe(-50);
+        expect(mn.slice(7).every((v) => v === -50)).toBe(true);
+    });
+
+    it('matches an independent running max/min over close', async () => {
+        const { plots } = await mk('2024-01-01', '2024-01-10').run(`//@version=5
+indicator("t")
+plot(close, "c")
+plot(ta.max(close), "mx")
+plot(ta.min(close), "mn")`);
+
+        const c = plots['c'].data.map((p) => p.value);
+        const mx = plots['mx'].data.map((p) => p.value);
+        const mn = plots['mn'].data.map((p) => p.value);
+        expect(c.length).toBeGreaterThan(100);
+
+        let runMax = -Infinity;
+        let runMin = Infinity;
+        for (let i = 0; i < c.length; i++) {
+            runMax = Math.max(runMax, c[i]);
+            runMin = Math.min(runMin, c[i]);
+            expect(mx[i]).toBeCloseTo(runMax, 8);
+            expect(mn[i]).toBeCloseTo(runMin, 8);
+        }
+        // The trailing max/min must never move the "wrong" way
+        for (let i = 1; i < c.length; i++) {
+            expect(mx[i]).toBeGreaterThanOrEqual(mx[i - 1]);
+            expect(mn[i]).toBeLessThanOrEqual(mn[i - 1]);
+        }
+    });
+
+    it('returns na until the first non-na value and ignores later na values', async () => {
+        const { plots } = await mk().run(`//@version=5
+indicator("t")
+// na for bars 0-2, then a spike, then na again on bar 5 which must not reset/poison the result
+s = bar_index < 3 ? na : bar_index == 4 ? 500 : bar_index == 5 ? na : bar_index == 6 ? -5 : 10
+plot(ta.max(s), "mx")
+plot(ta.min(s), "mn")`);
+
+        const mx = plots['mx'].data.map((p) => p.value);
+        const mn = plots['mn'].data.map((p) => p.value);
+
+        expect(mx.slice(0, 3).every((v) => Number.isNaN(v))).toBe(true);
+        expect(mn.slice(0, 3).every((v) => Number.isNaN(v))).toBe(true);
+        // bar 3: 10
+        expect(mx[3]).toBe(10);
+        expect(mn[3]).toBe(10);
+        // bar 4: 500
+        expect(mx[4]).toBe(500);
+        expect(mn[4]).toBe(10);
+        // bar 5: na input -> carry previous
+        expect(mx[5]).toBe(500);
+        expect(mn[5]).toBe(10);
+        // bar 6: -5
+        expect(mx[6]).toBe(500);
+        expect(mn[6]).toBe(-5);
+        // afterwards stable
+        expect(mx[mx.length - 1]).toBe(500);
+        expect(mn[mn.length - 1]).toBe(-5);
+    });
+
+    it('keeps independent state across multiple call sites', async () => {
+        const { plots } = await mk().run(`//@version=5
+indicator("t")
+a = bar_index == 2 ? 7 : 1
+b = bar_index == 4 ? 3 : 1
+plot(ta.max(a), "ma")
+plot(ta.max(b), "mb")
+plot(ta.min(a), "na")
+plot(ta.min(b), "nb")`);
+
+        const last = (k: string) => plots[k].data[plots[k].data.length - 1].value;
+        expect(last('ma')).toBe(7);
+        expect(last('mb')).toBe(3);
+        expect(last('na')).toBe(1);
+        expect(last('nb')).toBe(1);
+        // ma must jump at bar 2, mb at bar 4 — proves the two calls don't share state
+        expect(plots['ma'].data[2].value).toBe(7);
+        expect(plots['mb'].data[2].value).toBe(1);
+        expect(plots['mb'].data[4].value).toBe(3);
+    });
+
+    it('works via the PineTS ($) syntax as well', async () => {
+        const { plots } = await mk().run(($) => {
+            const { close } = $.data;
+            const { ta, plot } = $.pine;
+            const mx = ta.max(close);
+            const mn = ta.min(close);
+            plot(mx, 'mx');
+            plot(mn, 'mn');
+            plot(close, 'c');
+            return { mx, mn };
+        });
+        const c = plots['c'].data.map((p) => p.value);
+        expect(plots['mx'].data[plots['mx'].data.length - 1].value).toBeCloseTo(Math.max(...c), 8);
+        expect(plots['mn'].data[plots['mn'].data.length - 1].value).toBeCloseTo(Math.min(...c), 8);
+    });
+});


### PR DESCRIPTION
## Summary

Adds `ta.max(source)` and `ta.min(source)` — the trailing (all-time) maximum / minimum of a series from the first bar of the chart to the current bar.

Both were listed as ✅ in `docs/api-coverage/ta.md` but did not exist in `src/namespaces/ta/methods/`, so any script calling them failed at runtime with `ta.max is not a function`.

## Implementation

- `src/namespaces/ta/methods/max.ts`, `min.ts` — same factory / `_callId` pattern as `cum.ts`
  - O(1) per bar, committed/tentative state keyed by `context.idx` so re-evaluation of the live bar does not corrupt history
  - `na` until the first non-na `source` value; later `na` values are ignored and the previous result is carried forward
  - Per-call-site state isolation via `_callId`
  - Output through `context.precision()`
- `src/namespaces/ta/ta.index.ts` — regenerated with `npm run generate:ta-index`

## Tests

`tests/namespaces/ta/trailing-max-min.test.ts` (5 tests). Expected values are independent of the implementation:

- hand-built step series (`bar_index == 3 ? 100 : bar_index == 7 ? -50 : 0`) with hand-derived expectations
- plain JS running max/min over the plotted `close` series as the reference, plus monotonicity checks
- `na` handling (leading na, interior na)
- state isolation across two call sites
- PineTS `($)` syntax path

Tests were confirmed failing (`ta.max is not a function`) before the implementation and passing after.

Full suite: 171 files / 1851 tests passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive TA indicators with isolated per-call state and broad test coverage; no changes to auth, data, or existing indicator behavior.
> 
> **Overview**
> Implements **`ta.max(source)`** and **`ta.min(source)`** so scripts can compute the running all-time high/low from the first bar through the current bar. These APIs were marked as covered in docs but were missing at runtime (`ta.max is not a function`).
> 
> Each function uses the same **`cum`-style** factory: O(1) per bar, **`context.taState`** with committed vs tentative values keyed by **`context.idx`** (safe live-bar re-evaluation), **`_callId`** for separate call sites, **`na`** until the first valid input with later **`na`** carried forward, and **`context.precision()`** on output. **`ta.index.ts`** wires both into the generated TA namespace.
> 
> Adds **`trailing-max-min.test.ts`** with step-series checks, independent running max/min over mock **`close`**, **`na`** behavior, multi-call state isolation, and the PineTS **`$`** syntax path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fca66cda845eeb7f7d8a3f03d21141ac77f4285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->