### PR TITLE
Evaluate ?: branches and v6 and/or operands lazily instead of hoisting them

### DIFF
--- a/docs/architecture/transpiler/transformers.md
+++ b/docs/architecture/transpiler/transformers.md
@@ -43,4 +43,5 @@ Handles expressions, primarily function calls and binary operations.
     1. Calculate SMA -> temp var.
     2. Calculate EMA using temp var.
     This simplifies the generated code and ensures proper order of operations for stateful functions.
+*   **Lazy operands (no hoisting)**: Pine evaluates `?:` branches lazily in every version, and the right operand of `and` / `or` lazily from v6 (v5 is strict). Hoisting a call out of such a position would run it unconditionally — `size(a) > 0 ? array.get(a, 0) : na` would throw on an empty array, and a `ta.*` call in an untaken branch would execute on every bar. `analysis/LazyOperandPass.ts` tags nodes in lazy positions with `_lazyOperand`; `transformCallExpression` then keeps those calls inline (hoisting suppressed for the call and its arguments) and the expression walkers stop descending into them (`isInlinedLazyCall`). Built-in TA *variables* (`ta.tr`, `ta.obv`, …) are the exception and are still hoisted to the script body via `addOuterHoistedStatement`, because they must run on every bar regardless of position.
 

--- a/src/transpiler/analysis/LazyOperandPass.ts
+++ b/src/transpiler/analysis/LazyOperandPass.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Lazy-operand marking pass.
+ *
+ * Pine evaluates some operands lazily, and PineTS must not execute them when
+ * TradingView would not:
+ *
+ *   - `cond ? a : b`  — only the taken branch is evaluated (every Pine version).
+ *   - `a and b`, `a or b` — the right operand is skipped once the result is
+ *     known in Pine v6+ (and in JavaScript). Pine v5 evaluates both operands
+ *     strictly, so for v5 sources `lazyLogical` must be `false`.
+ *
+ * Reference: TradingView, "To Pine Script version 6" migration guide,
+ * "Lazy evaluation of conditions".
+ *
+ * The transformation pass normally hoists every namespace call it meets into
+ * a `const temp_N = ...` statement emitted *before* the enclosing statement.
+ * That is fine for eager positions, but for a lazy operand it turns
+ * `size(a) > 0 ? array.get(a, 0) : na` into an unconditional `array.get`
+ * that throws on an empty array, and makes stateful `ta.*` calls in an
+ * untaken branch run on every bar.
+ *
+ * This pass runs on the clean AST (before transformation) and tags every node
+ * that sits inside a lazy operand with `_lazyOperand = true`. The call
+ * transformer then keeps such calls inline (hoisting suppressed) so they are
+ * evaluated exactly when the surrounding JS expression evaluates them.
+ *
+ * Function bodies (IIFEs generated for Pine `if`/`switch` expressions) reset
+ * the flag: statements inside them get their own hoisting scope, which is
+ * already lazy because the IIFE itself only runs when its branch is taken.
+ */
+export interface LazyOperandOptions {
+    /** Treat the right operand of `&&` / `||` / `??` as lazy. */
+    lazyLogical: boolean;
+}
+
+const FUNCTION_TYPES = new Set(['ArrowFunctionExpression', 'FunctionExpression', 'FunctionDeclaration']);
+const LAZY_LOGICAL_OPERATORS = new Set(['&&', '||', '??']);
+
+function isNode(value: any): boolean {
+    return value !== null && typeof value === 'object' && typeof value.type === 'string';
+}
+
+function visit(node: any, lazy: boolean, opts: LazyOperandOptions): void {
+    if (!isNode(node)) return;
+
+    if (lazy) node._lazyOperand = true;
+
+    if (FUNCTION_TYPES.has(node.type)) {
+        // Parameters/defaults are evaluated with the call; the body has its own
+        // hoisting scope and is therefore already lazy relative to its caller.
+        if (Array.isArray(node.params)) node.params.forEach((p: any) => visit(p, lazy, opts));
+        visit(node.body, false, opts);
+        return;
+    }
+
+    if (node.type === 'ConditionalExpression') {
+        visit(node.test, lazy, opts);
+        visit(node.consequent, true, opts);
+        visit(node.alternate, true, opts);
+        return;
+    }
+
+    if (node.type === 'LogicalExpression' && opts.lazyLogical && LAZY_LOGICAL_OPERATORS.has(node.operator)) {
+        visit(node.left, lazy, opts);
+        visit(node.right, true, opts);
+        return;
+    }
+
+    for (const key of Object.keys(node)) {
+        if (key === 'parent' || key.startsWith('_')) continue;
+        const child = node[key];
+        if (Array.isArray(child)) {
+            child.forEach((c) => visit(c, lazy, opts));
+        } else if (isNode(child)) {
+            visit(child, lazy, opts);
+        }
+    }
+}
+
+export function markLazyOperands(ast: any, opts: LazyOperandOptions): void {
+    visit(ast, false, opts);
+}

--- a/src/transpiler/analysis/ScopeManager.ts
+++ b/src/transpiler/analysis/ScopeManager.ts
@@ -587,7 +587,14 @@ export class ScopeManager {
      *   [2+] = inner scopes (if-blocks, loops, etc.)
      */
     addOuterHoistedStatement(stmt: any): void {
-        if (this.hoistingStack.length > 0 && !this.suppressHoisting) {
+        // Deliberately ignores `suppressHoisting`: that flag keeps calls inline
+        // in positions where they must be evaluated conditionally (while-loop
+        // tests, lazy `?:` / `and` / `or` operands). Built-in TA *variables*
+        // (ta.tr, ta.obv, ...) are the opposite case — they must run on every
+        // bar regardless of where they are referenced — so they always go to
+        // the script body scope. Dropping the statement here would leave the
+        // generated code referencing an undeclared `temp_N`.
+        if (this.hoistingStack.length > 0) {
             const targetIndex = Math.min(1, this.hoistingStack.length - 1);
             this.hoistingStack[targetIndex].push(stmt);
         }

--- a/src/transpiler/index.ts
+++ b/src/transpiler/index.ts
@@ -54,6 +54,7 @@ import { normalizeNativeImports } from './transformers/NormalizationTransformer'
 import { wrapInContextFunction } from './transformers/WrapperTransformer';
 import { transformNestedArrowFunctions, preProcessContextBoundVars, preProcessUdtRegistry, runAnalysisPass } from './analysis/AnalysisPass';
 import { runTypeInferencePass } from './analysis/TypeInferencePass';
+import { markLazyOperands } from './analysis/LazyOperandPass';
 import { runTransformationPass, transformEqualityChecks, propagateAsyncAwait } from './transformers/MainTransformer';
 import { extractPineScriptVersion, pineToJS } from './pineToJS/pineToJS.index';
 import { buildLtfSlices } from './slicing/buildLtfSlices';
@@ -146,6 +147,14 @@ export function transpile(source: string | Function, options: { debug: boolean; 
     if (pineVersion !== null && pineVersion < 6) {
         runTypeInferencePass(ast, scopeManager);
     }
+
+    // Lazy operands: tag nodes inside `?:` branches (every version) and the
+    // right operand of `and`/`or` (Pine v6+, and JS `&&`/`||` for PineTS
+    // syntax) so the call transformer keeps their namespace calls inline
+    // instead of hoisting them into unconditional temps. Pine v5 evaluates
+    // `and`/`or` strictly (see TradingView's v6 migration guide, "Lazy
+    // evaluation of conditions"), so v5 keeps the eager right operand.
+    markLazyOperands(ast, { lazyLogical: pineVersion === null || pineVersion >= 6 });
 
     // Second pass: transform the code
     runTransformationPass(ast, scopeManager, originalParamName, options, sourceLines);

--- a/src/transpiler/transformers/ExpressionTransformer.ts
+++ b/src/transpiler/transformers/ExpressionTransformer.ts
@@ -928,6 +928,8 @@ function getParamFromConditionalExpression(node: any, scopeManager: ScopeManager
                 // First transform the call expression itself
                 transformCallExpression(node, scopeManager);
 
+                if (isInlinedLazyCall(node)) return;
+
                 // Then transform its arguments with the correct context
                 node.arguments.forEach((arg: any) => c(arg, { parent: node, inNamespaceCall: isNamespaceCall || state.inNamespaceCall }));
             },
@@ -1417,12 +1419,47 @@ function resolveCalleeObject(node: any, parentNode: any, scopeManager: ScopeMana
     }
 }
 
+/**
+ * True when `transformCallExpression` kept a lazy-operand call inline (see
+ * LazyOperandPass). Such a node is fully transformed — callee and arguments
+ * included — and, unlike an eager call, was NOT replaced by a hoisted
+ * `temp_N` identifier. Expression walkers that descend into a call's callee /
+ * arguments after transforming it must stop here, otherwise they re-run
+ * `transformMemberExpression` on `ns.method` / `ns.param` callees and turn
+ * them into bogus `ns.method()(...)` auto-calls.
+ */
+export function isInlinedLazyCall(node: any): boolean {
+    return !!node && node.type === 'CallExpression' && node._transformed === true && node._lazyOperand === true;
+}
+
 export function transformCallExpression(node: any, scopeManager: ScopeManager, namespace?: string): void {
     // Skip if this node has already been transformed
     if (node._transformed) {
         return;
     }
 
+    // Calls sitting in a lazy operand (`?:` branch, or the right side of a
+    // lazy `and`/`or` — see LazyOperandPass) must stay inline: hoisting them
+    // into a `const temp_N = ...` ahead of the statement would evaluate them
+    // unconditionally, e.g. running `array.get(a, 0)` even when the guard
+    // `array.size(a) > 0` is false, or executing a stateful `ta.*` call on
+    // bars where TradingView would skip it. Suppressing hoisting for the
+    // duration of this call (arguments included) keeps every generated
+    // `ns.param(...)` / nested call inside the branch expression.
+    if (node._lazyOperand === true && !scopeManager.shouldSuppressHoisting()) {
+        scopeManager.setSuppressHoisting(true);
+        try {
+            transformCallExpressionInner(node, scopeManager, namespace);
+        } finally {
+            scopeManager.setSuppressHoisting(false);
+        }
+        return;
+    }
+
+    transformCallExpressionInner(node, scopeManager, namespace);
+}
+
+function transformCallExpressionInner(node: any, scopeManager: ScopeManager, namespace?: string): void {
     if (node.callee && node.callee.name === 'kernel_matrix') {
         // console.log('Transforming kernel_matrix call');
         // console.log('Arguments before:', node.arguments.map((a: any) => a.name));

--- a/src/transpiler/transformers/StatementTransformer.ts
+++ b/src/transpiler/transformers/StatementTransformer.ts
@@ -8,6 +8,7 @@ import { NAMESPACES_LIKE, FACTORY_METHODS } from '../settings';
 import {
     transformIdentifier,
     transformCallExpression,
+    isInlinedLazyCall,
     transformMemberExpression,
     transformArrayIndex,
     addArrayAccess,
@@ -203,7 +204,7 @@ export function transformAssignmentExpression(node: any, scopeManager: ScopeMana
                 // First transform the call expression itself
                 transformCallExpression(node, scopeManager);
 
-                if (node.type !== 'CallExpression') return;
+                if (node.type !== 'CallExpression' || isInlinedLazyCall(node)) return;
 
                 // Traverse the callee if it's a MemberExpression (to handle obj.method())
                 if (node.callee.type === 'MemberExpression') {
@@ -406,7 +407,7 @@ export function transformVariableDeclaration(varNode: any, scopeManager: ScopeMa
 
                             transformCallExpression(node, scopeManager);
 
-                            if (node.type !== 'CallExpression') return;
+                            if (node.type !== 'CallExpression' || isInlinedLazyCall(node)) return;
 
                             // Traverse the callee if it's a MemberExpression (to handle obj.method())
                             if (node.callee.type === 'MemberExpression') {
@@ -514,6 +515,24 @@ export function transformVariableDeclaration(varNode: any, scopeManager: ScopeMa
                                 });
                                 node.body.body = newBody;
                             }
+                        },
+                        BlockStatement(node: any, state: any, c: any) {
+                            // Nested blocks inside an IIFE (the `if`/`else` bodies that a Pine
+                            // `switch` or multi-line `if` expression compiles to) need their own
+                            // per-statement hoisting scope, exactly like the IIFE body above and
+                            // the BlockStatement handlers of the return-statement / arrow-body
+                            // walkers. Without it, `if (c) { return array.get(a, 0) }` hoists the
+                            // `array.get` temp to the IIFE body, ahead of the `if`, so the untaken
+                            // branch is evaluated anyway (and throws on an empty array).
+                            const newBody: any[] = [];
+                            node.body.forEach((stmt: any) => {
+                                scopeManager.enterHoistingScope();
+                                c(stmt, { ...state, parent: node });
+                                const hoistedStmts = scopeManager.exitHoistingScope();
+                                newBody.push(...hoistedStmts);
+                                newBody.push(stmt);
+                            });
+                            node.body = newBody;
                         },
                         SwitchStatement(node: any, state: any, c: any) {
                             // Traverse discriminant and all cases

--- a/tests/transpiler/lazy-conditional-operands.test.ts
+++ b/tests/transpiler/lazy-conditional-operands.test.ts
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Lazy evaluation of `?:` branches and `and` / `or` operands.
+ *
+ * Reference: TradingView's "To Pine Script version 6" migration guide, section
+ * "Lazy evaluation of conditions":
+ *
+ *   - `?:` is lazy in EVERY Pine version: only the taken branch is evaluated.
+ *     ("Pine v5 evaluates all bool expressions except for the `?:` ternary
+ *     operator strictly".)
+ *   - `and` / `or` are STRICT in v5 (both operands always evaluated) and LAZY
+ *     in v6 (the right operand is skipped once the result is known).
+ *   - Bare PineTS syntax is JavaScript, whose `&&` / `||` / `?:` are lazy.
+ *
+ * Historically the transpiler hoisted every namespace call inside these
+ * operands into an unconditional `temp_N` const ahead of the statement, so a
+ * guarded `array.get(a, 0)` ran even when `array.size(a) > 0` was false and
+ * threw "Index 0 is out of bounds". Stateful `ta.*` calls in an untaken
+ * branch were also executed on every bar, diverging from TradingView.
+ *
+ * Observable used for "was the branch executed on this bar?": `ta.cum(1)`
+ * counts the bars on which it was actually called, so its value on a given
+ * bar is a hand-derivable execution count.
+ */
+import { describe, it, expect } from 'vitest';
+import { PineTS } from '../../src/PineTS.class';
+import { Provider } from '../../src/marketData/Provider.class';
+
+function mk() {
+    return new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date('2024-01-01').getTime(), new Date('2024-01-10').getTime());
+}
+
+const pine = (version: 5 | 6, body: string) => `//@version=${version}\nindicator("t")\n${body}`;
+
+describe('?: is lazy (all versions)', () => {
+    for (const v of [5, 6] as const) {
+        it(`v${v}: guarded array.get in a ternary branch does not throw on an empty array`, async () => {
+            const { plots } = await mk().run(
+                pine(v, `var a = array.new_float()
+x = array.size(a) > 0 ? array.get(a, 0) : na
+plot(x, "x")`)
+            );
+            const x = plots['x'].data.map((p) => p.value);
+            expect(x.length).toBeGreaterThan(0);
+            expect(x.every((val) => Number.isNaN(val))).toBe(true);
+        });
+
+        it(`v${v}: the alternate branch is lazy too`, async () => {
+            const { plots } = await mk().run(
+                pine(v, `var a = array.new_float()
+x = array.size(a) == 0 ? na : array.get(a, 0)
+plot(x, "x")`)
+            );
+            expect(plots['x'].data.every((p) => Number.isNaN(p.value))).toBe(true);
+        });
+
+        it(`v${v}: ta.* inside a ternary branch only executes on bars where the branch is taken`, async () => {
+            const { plots } = await mk().run(
+                pine(v, `// even bars: count executions; odd bars: -1
+x = bar_index % 2 == 0 ? ta.cum(1) : -1
+plot(x, "x")`)
+            );
+            const x = plots['x'].data.map((p) => p.value);
+            // Hand-derived under TV lazy semantics: on even bar 2k the branch has
+            // run k+1 times so far (bars 0, 2, ..., 2k).
+            expect(x[0]).toBe(1);
+            expect(x[1]).toBe(-1);
+            expect(x[2]).toBe(2);
+            expect(x[3]).toBe(-1);
+            expect(x[10]).toBe(6);
+            expect(x[20]).toBe(11);
+        });
+
+        it(`v${v}: ternary inside a user function is lazy`, async () => {
+            const { plots } = await mk().run(
+                pine(v, `f(arr) => array.size(arr) > 0 ? array.get(arr, 0) : na
+var a = array.new_float()
+plot(f(a), "x")`)
+            );
+            expect(plots['x'].data.every((p) => Number.isNaN(p.value))).toBe(true);
+        });
+
+        it(`v${v}: ternary passed directly as a function argument is lazy`, async () => {
+            const { plots } = await mk().run(
+                pine(v, `var a = array.new_float()
+plot(array.size(a) > 0 ? array.get(a, 0) : na, "x")`)
+            );
+            expect(plots['x'].data.every((p) => Number.isNaN(p.value))).toBe(true);
+        });
+
+        it(`v${v}: nested call inside the taken branch still works and gets its arguments`, async () => {
+            const { plots } = await mk().run(
+                pine(v, `var a = array.from(1.0, 2.0, 3.0)
+x = array.size(a) > 0 ? math.max(array.get(a, 0), array.get(a, 2)) : na
+plot(x, "x")`)
+            );
+            expect(plots['x'].data.every((p) => p.value === 3)).toBe(true);
+        });
+
+        it(`v${v}: built-in ta variable (ta.tr) inside a ternary branch works`, async () => {
+            const { plots } = await mk().run(
+                pine(v, `x = bar_index % 2 == 0 ? ta.tr : 0
+plot(x, "x")
+plot(ta.tr, "ref")`)
+            );
+            const x = plots['x'].data.map((p) => p.value);
+            const ref = plots['ref'].data.map((p) => p.value);
+            expect(x[2]).toBeCloseTo(ref[2], 8);
+            expect(x[3]).toBe(0);
+        });
+
+        it(`v${v}: built-in ta variable as an argument of a call inside a ternary branch works`, async () => {
+            const { plots } = await mk().run(
+                pine(v, `x = bar_index % 2 == 0 ? math.max(ta.tr, 0) : 0
+plot(x, "x")
+plot(ta.tr, "ref")`)
+            );
+            const x = plots['x'].data.map((p) => p.value);
+            const ref = plots['ref'].data.map((p) => p.value);
+            expect(x[2]).toBeCloseTo(ref[2], 8);
+            expect(x[3]).toBe(0);
+        });
+    }
+});
+
+describe('and / or: strict in v5, lazy in v6 (TradingView semantics)', () => {
+    it('v6: `size > 0 and get(...)` guard does not throw on an empty array', async () => {
+        const { plots } = await mk().run(
+            pine(6, `var a = array.new_float()
+y = array.size(a) > 0 and array.get(a, 0) > 0
+plot(y ? 1 : 0, "y")`)
+        );
+        expect(plots['y'].data.every((p) => p.value === 0)).toBe(true);
+    });
+
+    it('v6: `size == 0 or get(...)` guard does not throw on an empty array', async () => {
+        const { plots } = await mk().run(
+            pine(6, `var a = array.new_float()
+z = array.size(a) == 0 or array.get(a, 0) > 0
+plot(z ? 1 : 0, "z")`)
+        );
+        expect(plots['z'].data.every((p) => p.value === 1)).toBe(true);
+    });
+
+    it('v6: ta.* on the right of `and` only runs when the left side is true', async () => {
+        const { plots } = await mk().run(
+            pine(6, `// cum executes only on even bars: its k-th execution happens on bar 2(k-1)
+flag = bar_index % 2 == 0 and ta.cum(1) >= 50
+plot(flag ? 1 : 0, "f")`)
+        );
+        const f = plots['f'].data.map((p) => p.value);
+        // 50th execution is on bar 98 -> first true at bar 98, false before
+        expect(f[50]).toBe(0);
+        expect(f[96]).toBe(0);
+        expect(f[98]).toBe(1);
+    });
+
+    it('v5: ta.* on the right of `and` runs on every bar (strict evaluation)', async () => {
+        const { plots } = await mk().run(
+            pine(5, `flag = bar_index % 2 == 0 and ta.cum(1) >= 50
+plot(flag ? 1 : 0, "f")`)
+        );
+        const f = plots['f'].data.map((p) => p.value);
+        // cum runs every bar: cum = bar_index + 1, so >= 50 from bar 49; first even bar is 50
+        expect(f[48]).toBe(0);
+        expect(f[50]).toBe(1);
+        expect(f[51]).toBe(0);
+        expect(f[52]).toBe(1);
+    });
+
+    it('v5: `and` guard is strict, so the guarded array.get still throws (as it does on TradingView v5)', async () => {
+        await expect(
+            mk().run(
+                pine(5, `var a = array.new_float()
+y = array.size(a) > 0 and array.get(a, 0) > 0
+plot(y ? 1 : 0, "y")`)
+            )
+        ).rejects.toThrow(/out of bounds/);
+    });
+});
+
+describe('switch expression arms are lazy (compiled to an IIFE with if/else)', () => {
+    // A Pine `switch` used as an expression compiles to an IIFE whose arms are
+    // `if (...) { return <arm> }` blocks. Calls inside those blocks used to be
+    // hoisted to the IIFE body ahead of the `if`, so every arm ran on every bar.
+
+    it('guarded array.get in a switch arm does not throw (declaration)', async () => {
+        const { plots } = await mk().run(
+            pine(5, `var a = array.new_float()
+x = switch
+    array.size(a) > 0 => array.get(a, 0)
+    => na
+plot(x, "x")`)
+        );
+        expect(plots['x'].data.every((p) => Number.isNaN(p.value))).toBe(true);
+    });
+
+    it('guarded array.get in a switch arm does not throw (reassignment)', async () => {
+        const { plots } = await mk().run(
+            pine(5, `var a = array.new_float()
+float x = na
+x := switch
+    array.size(a) > 0 => array.get(a, 0)
+    => -1
+plot(x, "x")`)
+        );
+        expect(plots['x'].data.every((p) => p.value === -1)).toBe(true);
+    });
+
+    it('guarded array.get in a switch arm does not throw (function return)', async () => {
+        const { plots } = await mk().run(
+            pine(5, `f(arr) =>
+    switch
+        array.size(arr) > 0 => array.get(arr, 0)
+        => na
+var a = array.new_float()
+plot(f(a), "x")`)
+        );
+        expect(plots['x'].data.every((p) => Number.isNaN(p.value))).toBe(true);
+    });
+
+    it('ta.* in a switch arm only executes on bars where the arm is taken', async () => {
+        const { plots } = await mk().run(
+            pine(5, `x = switch bar_index % 2
+    0 => ta.cum(1)
+    => -1
+plot(x, "x")`)
+        );
+        const x = plots['x'].data.map((p) => p.value);
+        expect(x.slice(0, 5)).toEqual([1, -1, 2, -1, 3]);
+    });
+});
+
+describe('PineTS syntax (JavaScript semantics)', () => {
+    it('?: and && are lazy', async () => {
+        const { plots } = await mk().run(($) => {
+            const { array, plot } = $.pine;
+            var a = array.new_float();
+            const x = array.size(a) > 0 ? array.get(a, 0) : NaN;
+            const y = array.size(a) > 0 && array.get(a, 0) > 0;
+            plot(x, 'x');
+            plot(y ? 1 : 0, 'y');
+            return { x, y };
+        });
+        expect(plots['x'].data.every((p) => Number.isNaN(p.value))).toBe(true);
+        expect(plots['y'].data.every((p) => p.value === 0)).toBe(true);
+    });
+});
+
+describe('unchanged: eager positions still hoist and run every bar', () => {
+    it('ta.* in the ternary TEST runs every bar', async () => {
+        const { plots } = await mk().run(
+            pine(5, `x = ta.cum(1) >= 3 ? 1 : 0
+plot(x, "x")`)
+        );
+        const x = plots['x'].data.map((p) => p.value);
+        expect(x.slice(0, 2)).toEqual([0, 0]);
+        expect(x[2]).toBe(1);
+        expect(x[5]).toBe(1);
+    });
+
+    it('ta.* on the LEFT of `and` runs every bar (v6)', async () => {
+        const { plots } = await mk().run(
+            pine(6, `flag = ta.cum(1) >= 3 and bar_index % 2 == 0
+plot(flag ? 1 : 0, "f")`)
+        );
+        const f = plots['f'].data.map((p) => p.value);
+        expect(f[2]).toBe(1);
+        expect(f[3]).toBe(0);
+        expect(f[4]).toBe(1);
+    });
+});


### PR DESCRIPTION
Fixes #297. Also addresses #267 item A1 (drawing constructors inside ternaries executed on every bar).

## Problem

The transpiler hoisted every namespace call inside a `?:` branch or an `and`/`or` operand into an unconditional `const temp_N = ...` ahead of the statement. So

```pine
x = array.size(a) > 0 ? array.get(a, 0) : na
```

threw `Index 0 is out of bounds` on an empty array even though the guard was false, and a stateful `ta.*` call in an untaken branch was executed on every bar, diverging from TradingView.

## Semantics implemented (per TradingView's v6 migration guide, "Lazy evaluation of conditions")

| Position | Pine v5 | Pine v6+ | PineTS / JS syntax |
| --- | --- | --- | --- |
| `?:` branches | lazy | lazy | lazy |
| `and` / `or` right operand | **strict** (both sides run) | lazy | lazy |

v5 `and`/`or` deliberately stays eager: on TradingView v5 `cond and ta.rsi(close, 14) > 50` runs `ta.rsi` every bar, so making it lazy would change indicator output for v5 scripts (and the guarded `array.get` throws on TV v5 too).

## Changes

- **`src/transpiler/analysis/LazyOperandPass.ts`** (new): pre-pass that tags nodes inside `?:` branches (always) and the right operand of `&&`/`||`/`??` (`pineVersion === null || >= 6`) with `_lazyOperand`. Function bodies reset the flag since their block scope is already lazy. Wired in `transpiler/index.ts` next to the existing version-gated `runTypeInferencePass`.
- **`transformCallExpression`**: suppresses hoisting for a tagged call (arguments included), so it stays inline in the branch expression. Reuses the `suppressHoisting` mechanism the `while`-header code already relies on.
- **`isInlinedLazyCall`**: the declaration / assignment / conditional-argument walkers stop descending into an inlined lazy call. They assumed the call had been replaced by a hoisted identifier and otherwise re-ran `transformMemberExpression` on the callee, emitting `ns.method()(...)`.
- **`ScopeManager.addOuterHoistedStatement`** no longer honours `suppressHoisting`. Built-in TA *variables* (`ta.tr`, `ta.obv`, …) must run every bar regardless of position; dropping the statement left the generated code referencing an undeclared `temp_N` (`cond ? math.max(ta.tr, 0) : 0`, and latent in `while` tests).
- **Declaration walker**: per-statement hoisting scope for nested `BlockStatement`s inside IIFEs, so Pine `switch` expression arms (compiled to `if (...) { return arm }`) are lazy too. Same handler the return-statement and arrow-body walkers already had.
- `docs/architecture/transpiler/transformers.md`: short note on the lazy exception to hoisting.

Generated code, before / after:

```js
// before
const temp_2 = array.size(p1);
const temp_3 = array.get(p2, p3);            // unconditional -> throws
$.let.glb1_x = $.init($.let.glb1_x, __gt(temp_2, 0) ? temp_3 : na);

// after
const temp_2 = array.size(p1);
$.let.glb1_x = $.init($.let.glb1_x, __gt(temp_2, 0)
    ? array.get(array.param($.var.glb1_a, undefined, 'p2'), array.param(0, undefined, 'p3'))
    : na);
```

## Tests

`tests/transpiler/lazy-conditional-operands.test.ts` — 28 tests, expected values derived from TradingView's documented semantics rather than PineTS output. `ta.cum(1)` is used as an execution counter, which gives hand-derivable per-bar counts for lazy vs strict positions.

- `?:` lazy for v5 and v6: guarded `array.get` (both branches, inside a user function, as a direct call argument), `ta.*` executes only on taken bars, nested calls in the taken branch, `ta.tr` bare and as a call argument inside a branch.
- `and`/`or`: v6 lazy (guards don't throw; `ta.cum` on the right runs only when the left is true, first true at bar 98), v5 strict (`ta.cum` runs every bar, first true at bar 50; guarded `array.get` still throws as on TV v5).
- `switch` arms lazy in declaration, `:=` reassignment and function-return positions; `ta.*` in an arm counts only taken bars.
- PineTS `($)` syntax `?:` / `&&` lazy.
- Eager positions unchanged: `ta.*` in the ternary test and on the left of `and` still run every bar.

14 of the tests failed before the fix for the expected reasons (out-of-bounds throw; eager `ta.cum` counts), and pass after.

Full suite: 171 files / 1874 tests passing — the compatibility snapshots, which lock in current output for eager positions, are unchanged.

Also probed manually (not kept as tests): `request.security` inside a branch (inline `await`), `line.new`/`label.new` in a ternary (#267 A1, now created only on matching bars), user-function calls, history operator on a call in a branch, `$$`-scoped `ta.*` inside a user function, `color.new` in a `plot` color argument, lazy branches inside `if`/`for` bodies, `while` tests.

## Not in scope (pre-existing, noticed while probing)

A multi-statement `if`-expression that returns a local (`x = if c` / `v = ...` / `v` / `else` / `-1`) yields `na` on every bar on `dev` as well; separate bug, not touched here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core expression hoisting and call lowering across all scripts; behavior changes are intentional for lazy positions but could affect edge cases around nested calls and TA builtins inside conditionals.
> 
> **Overview**
> Stops **unconditional hoisting** of namespace/`ta.*` calls inside operands that Pine (and JS) only evaluate when a branch is taken. Previously, hoisting turned guarded patterns like `array.size(a) > 0 ? array.get(a, 0) : na` into eager temps and broke TradingView semantics (throws, wrong bar-by-bar `ta.*` state).
> 
> Adds **`markLazyOperands`** before the main transform: tags `?:` consequent/alternate (all Pine versions) and the right side of `&&` / `||` / `??` when `lazyLogical` is on (Pine v6+, PineTS/JS). **`transformCallExpression`** keeps tagged calls **inline** via `suppressHoisting`; walkers bail with **`isInlinedLazyCall`** so callees are not double-transformed. **`addOuterHoistedStatement`** still hoists built-in TA *variables* (`ta.tr`, etc.) every bar even when `suppressHoisting` is set. **Nested `BlockStatement`s inside switch/if IIFEs** get per-statement hoisting scopes so switch arms stay lazy.
> 
> Docs note the lazy-operand exception; **`lazy-conditional-operands.test.ts`** locks v5 strict vs v6 lazy `and`/`or`, ternary, switch, and PineTS `&&`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0161564a8930a79bbb221a6f51d86fabbd784c06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->