### PR TITLE
fix(pineToJS): allow the `_` discard identifier to be declared multiple times

### DIFF
--- a/src/transpiler/pineToJS/codegen.ts
+++ b/src/transpiler/pineToJS/codegen.ts
@@ -35,6 +35,35 @@ export class CodeGenerator {
         this.functionParams = new Map();
     }
 
+    /**
+     * Pine Script treats `_` as a write-only discard identifier: it may be
+     * declared any number of times, in any scope, including several times in
+     * the same scope (`[_, s, _] = ...` followed by `[_, t, _] = ...`, or a
+     * plain `_ = expr` repeated). JavaScript forbids re-declaring a `let`/`var`
+     * binding in one scope, so every `_` declaration target is renamed to a
+     * fresh `_$N` placeholder. `$` is not a legal Pine identifier character,
+     * so the placeholders can never collide with user variables.
+     *
+     * Non-`_` duplicates inside one tuple (invalid Pine, but tolerated) fall
+     * back to a numeric suffix so the generated destructuring stays valid JS.
+     */
+    private renameDiscardTargets(elements: any[]) {
+        const seen = new Set<string>();
+        for (const el of elements) {
+            if (!el || el.type !== 'Identifier') continue;
+            if (el.name === '_') {
+                el.name = this.freshDiscardName();
+            } else if (seen.has(el.name)) {
+                el.name = `${el.name}${this.paramRenameCounter++}`;
+            }
+            seen.add(el.name);
+        }
+    }
+
+    private freshDiscardName(): string {
+        return `_$${this.paramRenameCounter++}`;
+    }
+
     generate(ast) {
         this.output = [];
         this.indent = 0;
@@ -657,6 +686,14 @@ export class CodeGenerator {
         for (let i = 0; i < node.declarations.length; i++) {
             const decl = node.declarations[i];
 
+            // Pine's `_` discard identifier may be re-declared freely; give each
+            // occurrence a unique JS name before any path below reads `decl.id`.
+            if (decl.id?.type === 'Identifier' && decl.id.name === '_') {
+                decl.id.name = this.freshDiscardName();
+            } else if (decl.id?.type === 'ArrayPattern') {
+                this.renameDiscardTargets(decl.id.elements);
+            }
+
             // Check if init is a complex if expression that needs statement-based generation
             if (decl.init && decl.init.type === 'ConditionalExpression' && decl.init.needsIIFE) {
                 // Generate: let varName;\n if (...) { varName = ... } else { varName = ... }
@@ -684,23 +721,9 @@ export class CodeGenerator {
             if (decl.id.type === 'Identifier') {
                 this.write(decl.id.name);
             } else if (decl.id.type === 'ArrayPattern') {
-                // Tuple destructuring — deduplicate discard placeholders like `_`
-                // Pine Script allows [a, _, _] but JS forbids duplicate names in destructuring
-                const seen = new Set<string>();
+                // Tuple destructuring (`_` targets already renamed above)
                 this.write('[');
-                for (let j = 0; j < decl.id.elements.length; j++) {
-                    let name = decl.id.elements[j].name;
-                    if (seen.has(name)) {
-                        const unique = `${name}${this.paramRenameCounter++}`;
-                        decl.id.elements[j].name = unique;
-                        name = unique;
-                    }
-                    seen.add(name);
-                    this.write(name);
-                    if (j < decl.id.elements.length - 1) {
-                        this.write(', ');
-                    }
-                }
+                this.write(decl.id.elements.map((el) => el.name).join(', '));
                 this.write(']');
             }
 
@@ -1096,22 +1119,10 @@ export class CodeGenerator {
                 if (decl.id.type === 'Identifier') {
                     this.write(decl.id.name);
                 } else if (decl.id.type === 'ArrayPattern') {
-                    // Destructuring: [a, b] — deduplicate discard placeholders
-                    const seen = new Set<string>();
+                    // Destructuring: [a, b] — rename `_` discard placeholders
+                    this.renameDiscardTargets(decl.id.elements);
                     this.write('[');
-                    for (let i = 0; i < decl.id.elements.length; i++) {
-                        let name = decl.id.elements[i].name;
-                        if (seen.has(name)) {
-                            const unique = `${name}${this.paramRenameCounter++}`;
-                            decl.id.elements[i].name = unique;
-                            name = unique;
-                        }
-                        seen.add(name);
-                        this.write(name);
-                        if (i < decl.id.elements.length - 1) {
-                            this.write(', ');
-                        }
-                    }
+                    this.write(decl.id.elements.map((el) => el.name).join(', '));
                     this.write(']');
                 }
 

--- a/tests/transpiler/underscore-discard-identifier.test.ts
+++ b/tests/transpiler/underscore-discard-identifier.test.ts
@@ -1,0 +1,195 @@
+// Regression guard: repeated `_` (discard) declarations.
+//
+// TradingView docs ("Using an underscore (_) as an identifier"):
+//   "You can assign any number of values to a `_` identifier anywhere in the
+//    script, even if the current scope already has such an assignment."
+//
+// Pine Script therefore allows:
+//   [_, s1, _] = ta.macd(...)
+//   [_, s2, _] = ta.macd(...)      // same scope, `_` re-declared
+//   _ = ta.sma(close, 10)          // plain declaration to `_`
+//   _ = ta.sma(close, 20)          // ... again
+//
+// JavaScript forbids re-declaring a `let`/`const` binding in the same scope,
+// so before the fix the generated code failed with
+//   SyntaxError: Identifier '_' has already been declared
+//
+// The fix (pineToJS codegen) renames every `_` declaration target to a fresh
+// `_$N` placeholder. `$` is not legal in Pine identifiers, so the placeholders
+// can never collide with user variables.
+import { describe, it, expect } from 'vitest';
+import { PineTS } from '../../src/PineTS.class';
+import { Provider } from '../../src/marketData/Provider.class';
+import { pineToJS } from '../../src/transpiler/pineToJS/pineToJS.index';
+
+function newPineTS() {
+    return new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date('2024-01-01').getTime(), new Date('2024-01-10').getTime());
+}
+
+function series(plots: any, title: string): number[] {
+    const data = plots[title]?.data;
+    expect(data, `plot "${title}" missing`).toBeDefined();
+    expect(data.length).toBeGreaterThan(0);
+    return data.map((d: any) => d.value);
+}
+
+/**
+ * Reference values: the same computations expressed WITHOUT `_`, using
+ * uniquely-named variables. This is plain, already-supported Pine, so it
+ * gives us an independent expectation for what the `_` variants must produce.
+ */
+async function reference() {
+    const { plots } = await newPineTS().run(`
+//@version=5
+indicator("reference")
+[m1, s1, h1] = ta.macd(close, 12, 26, 9)
+[m2, s2, h2] = ta.macd(close, 5, 10, 3)
+[bbm, bbu, bbl] = ta.bb(close, 20, 2)
+sma10 = ta.sma(close, 10)
+plot(s1, "s1")
+plot(s2, "s2")
+plot(m1, "m1")
+plot(h2, "h2")
+plot(bbu, "bbu")
+plot(bbl, "bbl")
+plot(sma10, "sma10")
+`);
+    return plots;
+}
+
+describe('`_` discard identifier can be declared multiple times (TV semantics)', () => {
+    it('two tuple declarations re-using `_` in the global scope', async () => {
+        const ref = await reference();
+        const { plots } = await newPineTS().run(`
+//@version=5
+indicator("t")
+[_, s1, _] = ta.macd(close, 12, 26, 9)
+[_, s2, _] = ta.macd(close, 5, 10, 3)
+plot(s1, "s1")
+plot(s2, "s2")
+`);
+        expect(series(plots, 's1')).toEqual(series(ref, 's1'));
+        expect(series(plots, 's2')).toEqual(series(ref, 's2'));
+    });
+
+    it('TradingView docs example: `_` re-used across two ta.bb() tuples', async () => {
+        const ref = await reference();
+        const { plots } = await newPineTS().run(`
+//@version=5
+indicator("Underscore demo")
+[_, bbUpper, bbLower] = ta.bb(close, 20, 2)
+[bbMiddleLong, _, _] = ta.bb(close, 20, 2)
+plot(bbUpper, "bbu")
+plot(bbLower, "bbl")
+plot(bbMiddleLong, "bbm")
+`);
+        expect(series(plots, 'bbu')).toEqual(series(ref, 'bbu'));
+        expect(series(plots, 'bbl')).toEqual(series(ref, 'bbl'));
+        // bbMiddleLong is the SMA(20) basis — compare against ta.sma via the
+        // reference's bb middle. Both come from the same ta.bb call shape.
+        const refPlots = await newPineTS().run(`
+//@version=5
+indicator("ref2")
+[bbm, u, l] = ta.bb(close, 20, 2)
+plot(bbm, "bbm")
+`);
+        expect(series(plots, 'bbm')).toEqual(series(refPlots.plots, 'bbm'));
+    });
+
+    it('plain `_ = expr` declared twice, then a real variable', async () => {
+        const ref = await reference();
+        const { plots } = await newPineTS().run(`
+//@version=5
+indicator("t")
+_ = ta.sma(close, 10)
+_ = ta.sma(close, 20)
+x = ta.sma(close, 10)
+plot(x, "x")
+`);
+        expect(series(plots, 'x')).toEqual(series(ref, 'sma10'));
+    });
+
+    it('tuple `_` followed by plain `_` in the same scope', async () => {
+        const ref = await reference();
+        const { plots } = await newPineTS().run(`
+//@version=5
+indicator("t")
+[m, _, _] = ta.macd(close, 12, 26, 9)
+_ = ta.sma(close, 10)
+plot(m, "m")
+`);
+        expect(series(plots, 'm')).toEqual(series(ref, 'm1'));
+    });
+
+    it('`_` re-declared inside a user function body', async () => {
+        const ref = await reference();
+        const { plots } = await newPineTS().run(`
+//@version=5
+indicator("t")
+f() =>
+    [_, a, _] = ta.macd(close, 12, 26, 9)
+    [_, _, b] = ta.macd(close, 5, 10, 3)
+    [a, b]
+[fa, fb] = f()
+plot(fa, "s1")
+plot(fb, "h2")
+`);
+        expect(series(plots, 's1')).toEqual(series(ref, 's1'));
+        expect(series(plots, 'h2')).toEqual(series(ref, 'h2'));
+    });
+
+    it('`_` re-declared in both if/else branches and after the if', async () => {
+        const ref = await reference();
+        const { plots } = await newPineTS().run(`
+//@version=5
+indicator("t")
+r = 0.0
+if true
+    [_, a, _] = ta.macd(close, 12, 26, 9)
+    r := a
+else
+    [_, b, _] = ta.macd(close, 5, 10, 3)
+    r := b
+[_, s2, _] = ta.macd(close, 5, 10, 3)
+_ = r
+plot(r, "s1")
+plot(s2, "s2")
+`);
+        expect(series(plots, 's1')).toEqual(series(ref, 's1'));
+        expect(series(plots, 's2')).toEqual(series(ref, 's2'));
+    });
+
+    it('`_` declared many times in a for-in loop body', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=5
+indicator("t")
+arr = array.from(1.0, 2.0, 3.0)
+total = 0.0
+for v in arr
+    _ = v * 2
+    _ = v * 3
+    total += v
+plot(total, "t")
+`);
+        const t = series(plots, 't');
+        expect(t[t.length - 1]).toBe(6);
+    });
+
+    it('generated JS never contains a bare `_` declaration', () => {
+        const out = pineToJS(`//@version=5
+indicator("t")
+[_, s1, _] = ta.macd(close, 12, 26, 9)
+_ = ta.sma(close, 10)
+plot(s1)
+`);
+        expect(out.success, out.error).toBe(true);
+        const js: string = out.code;
+        // Every `_` target must have been renamed to a unique `_$N` placeholder
+        expect(js).not.toMatch(/\b(let|const|var)\s+_\s*=/);
+        expect(js).not.toMatch(/\[\s*_\s*,/);
+        expect(js).not.toMatch(/,\s*_\s*\]/);
+        const placeholders = js.match(/_\$\d+/g) ?? [];
+        expect(placeholders.length).toBe(3);
+        expect(new Set(placeholders).size).toBe(3);
+    });
+});

--- a/tests/transpiler/underscore-discard-identifier.test.ts
+++ b/tests/transpiler/underscore-discard-identifier.test.ts
@@ -175,6 +175,49 @@ plot(total, "t")
         expect(t[t.length - 1]).toBe(6);
     });
 
+    // TradingView: "A value assigned to such a variable cannot be accessed."
+    // Reading `_` is a compile error on TV (`Undeclared identifier "_"`).
+    // PineTS surfaces every undeclared identifier as a ReferenceError at run
+    // time; `_` must behave the same way and never silently resolve to one of
+    // the discarded values.
+    describe('`_` is write-only: reading it fails like any undeclared identifier', () => {
+        it('plot(_) after a tuple declaration', async () => {
+            await expect(
+                newPineTS().run(`
+//@version=5
+indicator("t")
+[_, s1, _] = ta.macd(close, 12, 26, 9)
+plot(_, "u")
+`)
+            ).rejects.toThrow(/_ is not defined/);
+        });
+
+        it('`_` used in an expression after a plain declaration', async () => {
+            await expect(
+                newPineTS().run(`
+//@version=5
+indicator("t")
+_ = ta.sma(close, 10)
+x = _ + 1
+plot(x, "x")
+`)
+            ).rejects.toThrow(/_ is not defined/);
+        });
+
+        it('`_` read inside a user function body', async () => {
+            await expect(
+                newPineTS().run(`
+//@version=5
+indicator("t")
+f() =>
+    [_, a, _] = ta.macd(close, 12, 26, 9)
+    a + _
+plot(f(), "r")
+`)
+            ).rejects.toThrow(/_ is not defined/);
+        });
+    });
+
     it('generated JS never contains a bare `_` declaration', () => {
         const out = pineToJS(`//@version=5
 indicator("t")


### PR DESCRIPTION
## Problem

Pine Script treats `_` as a write-only discard identifier. Per the TradingView docs ([Variable declarations → Using an underscore (`_`) as an identifier](https://www.tradingview.com/pine-script-docs/language/variable-declarations/)):

> You can assign any number of values to a `_` identifier anywhere in the script, even if the current scope already has such an assignment.

PineTS only de-duplicated `_` *within a single tuple*, so any script that declared `_` more than once in the same scope failed at the JS stage:

```pine
//@version=5
indicator("t")
[_, s1, _] = ta.macd(close, 12, 26, 9)
[_, s2, _] = ta.macd(close, 5, 10, 3)   // SyntaxError: Identifier '_' has already been declared
_ = ta.sma(close, 10)                    // same
```

Reproduced failures (before the fix):

- two tuple declarations re-using `_` in the global scope
- the same inside a user function body
- plain `_ = expr` repeated
- tuple `_` followed by plain `_`
- `_` in an `if` branch followed by another `_` declaration after the `if`

## Fix

`src/transpiler/pineToJS/codegen.ts`: every `_` declaration target — plain declarations, tuple declarations, and `for [..] in` headers — is renamed to a fresh `_$N` placeholder via a shared `renameDiscardTargets` / `freshDiscardName` helper. `$` is not a legal Pine identifier character, so the placeholders can never collide with user variables (the same `_$N` scheme the codegen already uses for reserved-word renames).

Generated JS for the script above:

```js
let [_$0, s1, _$1] = ta.macd(close, 12, 26, 9);
let [_$2, s2, _$3] = ta.macd(close, 5, 10, 3);
let _$4 = ta.sma(close, 10);
```

The two previous copy-pasted intra-tuple dedup loops are replaced by the helper.

## `_` stays write-only

TradingView also says "A value assigned to such a variable cannot be accessed" — reading `_` is a compile error there (`Undeclared identifier "_"`). Because every declaration target is renamed, a *read* of `_` in the generated JS is a genuinely undeclared identifier and fails with `ReferenceError: _ is not defined` — the same way PineTS surfaces every other undeclared identifier. (Before this PR the first `_` in a tuple kept its name, so `plot(_)` silently returned the discarded value.) Tests pin this behavior.

## Tests

New `tests/transpiler/underscore-discard-identifier.test.ts` (11 tests):

- 7 positive cases covering all the scenarios above plus the TradingView docs `ta.bb` example and a for-in loop body. Expected values come from the same computations written with uniquely-named variables (already-supported Pine), so the tests assert correctness of the resulting series, not just "no throw". All failed before the fix with `Identifier '_' has already been declared`.
- 3 negative cases asserting that reading `_` (`plot(_)`, `_ + 1`, inside a function body) throws.
- 1 codegen check that no bare `_` declaration survives and each placeholder is unique.

Full suite: `npm test -- --run` → 175 files / 1863 tests passed, 0 failures.

## Notes

- `var [_, a, _] = ...` is still rejected by the parser (`Expected identifier after var`). This matches TradingView, which does not allow `var`/`varip` on tuple declarations.
- `_ := 5` (reassigning `_`) is not caught. This is pre-existing general behavior — any `:=` to an undeclared name (e.g. `foo := 5`) currently becomes a sloppy-mode global rather than an error — and is not specific to `_`, so it is left out of this PR.
- No runtime-transpiler (stage 2) changes.
