### PR TITLE
Fix scale and settlement_as_close namespaces not resolving in scripts

### DIFF
--- a/src/transpiler/settings.ts
+++ b/src/transpiler/settings.ts
@@ -162,6 +162,8 @@ export const NAMESPACE_COLLISION_NAMES = new Set([
     'dayofweek',
     'adjustment',
     'barmerge',
+    'scale',
+    'settlement_as_close',
 ]);
 
 // JavaScript reserved keywords that ARE valid Pine identifiers but invalid as
@@ -293,12 +295,16 @@ export const CONTEXT_PINE_VARS = [
     'extend',
     'position',
 
+    // Price scale constants (indicator(scale = scale.right))
+    'scale',
+
     // Merge constants (request.security)
     'barmerge',
 
     // Adjustment constants
     'adjustment',
     'backadjustment',
+    'settlement_as_close',
 
     // Financial data constants
     'earnings',

--- a/tests/namespaces/constants.test.ts
+++ b/tests/namespaces/constants.test.ts
@@ -439,4 +439,38 @@ describe('Constants', () => {
         expect(result.linestyle_dotted[0]).toBe('linestyle_dotted');
         expect(result.linestyle_dashed[0]).toBe('linestyle_dashed');
     });
+
+    // ── scale ──────────────────────────────────────────────────────────
+    it('scale.* constants match TradingView values', async () => {
+        const pineTS = makePineTS();
+
+        const { result } = await pineTS.run((context) => {
+            return {
+                left: scale.left,
+                none: scale.none,
+                right: scale.right,
+            };
+        });
+
+        expect(result.left[0]).toBe('left');
+        expect(result.none[0]).toBe('none');
+        expect(result.right[0]).toBe('right');
+    });
+
+    // ── settlement_as_close ────────────────────────────────────────────
+    it('settlement_as_close.* constants match TradingView values', async () => {
+        const pineTS = makePineTS();
+
+        const { result } = await pineTS.run((context) => {
+            return {
+                inherit: settlement_as_close.inherit,
+                off: settlement_as_close.off,
+                on: settlement_as_close.on,
+            };
+        });
+
+        expect(result.inherit[0]).toBe('inherit');
+        expect(result.off[0]).toBe('off');
+        expect(result.on[0]).toBe('on');
+    });
 });

--- a/tests/transpiler/namespace-identifier-collision.test.ts
+++ b/tests/transpiler/namespace-identifier-collision.test.ts
@@ -116,6 +116,27 @@ plot(dayofweek.friday, "p")
         expect(lastValue(plots, 'p')).toBe(6);
     });
 
+    // Both scripts compile on TradingView. Before the fix `scale` was missing from
+    // CONTEXT_PINE_VARS, so any `scale.*` reference threw `scale is not defined`.
+    it('scale: indicator(scale = scale.none) resolves the namespace', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("scale namespace", overlay = true, scale = scale.none)
+plot(close, "p")
+`);
+        expect(Number.isFinite(lastValue(plots, 'p'))).toBe(true);
+    });
+
+    it('scale: user variable coexists with indicator(scale = scale.left)', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("scale collision", scale = scale.left)
+scale = 2.0
+plot(scale, "p")
+`);
+        expect(lastValue(plots, 'p')).toBe(2);
+    });
+
     it('dual-use dayofweek built-in variable still works when not shadowed', async () => {
         const { plots } = await newPineTS().run(`
 //@version=6


### PR DESCRIPTION
## Problem

`scale` and `settlement_as_close` are defined in `src/namespaces/Types.ts`, spread into the context, and listed as supported in `docs/api-coverage/types.md`. They are missing from `CONTEXT_PINE_VARS`, though, so the transpiler never binds them. Any script that uses them fails:

```pine
//@version=6
indicator("repro", scale = scale.right)
plot(close)
```

→ `ReferenceError: scale is not defined`

This script compiles on TradingView. I ran 729 popular open-source indicators from TradingView through PineTS, and 12 of them failed on this.

## Fix

- Add `scale` and `settlement_as_close` to `CONTEXT_PINE_VARS`.
- Add both to `NAMESPACE_COLLISION_NAMES`. Scripts often declare their own `scale` variable next to `indicator(scale = scale.left)`, which TradingView allows.

## Tests

- `tests/namespaces/constants.test.ts`: the values of `scale.*` and `settlement_as_close.*`.
- `tests/transpiler/namespace-identifier-collision.test.ts`: `indicator(scale = scale.none)` with `overlay = true`, and a user variable named `scale`. Both scripts compile on TradingView.
- The 4 new tests fail on `dev` (`scale is not defined`) and pass with this change. Full suite: 1842 passed, 5 skipped, 16 todo.
- Differential check: all 729 indicators were run on identical cached market data, once against `dev` and once against this branch. 8 now run without errors. 4 get past `scale` and then stop at other unsupported features. The other scripts show no regressions and no changed output values. 8 scripts give different output on two identical `dev` runs, so I left them out of the value comparison.

The repro scripts and tooling are in https://github.com/lenstrats/pinets-compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
