### PR TITLE
Add table.cell_set_text_formatting and table.cell text_formatting

### DIFF
--- a/docs/api-coverage/pinescript-v6/table.json
+++ b/docs/api-coverage/pinescript-v6/table.json
@@ -6,7 +6,7 @@
         "table.cell_set_text()": true,
         "table.cell_set_text_color()": true,
         "table.cell_set_text_font_family()": true,
-        "table.cell_set_text_formatting()": false,
+        "table.cell_set_text_formatting()": true,
         "table.cell_set_text_halign()": true,
         "table.cell_set_text_size()": true,
         "table.cell_set_text_valign()": true,

--- a/docs/api-coverage/table.md
+++ b/docs/api-coverage/table.md
@@ -16,7 +16,7 @@ parent: API Coverage
 | `table.cell_set_text()`             | ✅     | Set cell text                  |
 | `table.cell_set_text_color()`       | ✅     | Set cell text color            |
 | `table.cell_set_text_font_family()` | ✅     | Set cell text font family      |
-| `table.cell_set_text_formatting()`  |        | Set cell text formatting       |
+| `table.cell_set_text_formatting()`  | ✅     | Set cell text formatting       |
 | `table.cell_set_text_halign()`      | ✅     | Set cell text horizontal align |
 | `table.cell_set_text_size()`        | ✅     | Set cell text size             |
 | `table.cell_set_text_valign()`      | ✅     | Set cell text vertical align   |

--- a/src/Context.class.ts
+++ b/src/Context.class.ts
@@ -525,6 +525,7 @@ export class Context {
                 'cell_set_text_halign',
                 'cell_set_text_valign',
                 'cell_set_text_font_family',
+                'cell_set_text_formatting',
                 'set_position',
                 'set_bgcolor',
                 'set_border_color',

--- a/src/namespaces/table/TableHelper.ts
+++ b/src/namespaces/table/TableHelper.ts
@@ -17,7 +17,7 @@ const TABLE_NEW_PARAMS = [
 //prettier-ignore
 const TABLE_CELL_PARAMS = [
     'column', 'row', 'text', 'width', 'height', 'text_color', 'text_halign',
-    'text_valign', 'text_size', 'bgcolor', 'tooltip', 'text_font_family',
+    'text_valign', 'text_size', 'bgcolor', 'tooltip', 'text_font_family', 'text_formatting',
 ];
 const TABLE_RANGE_PARAMS = ['start_column', 'start_row', 'end_column', 'end_row'];
 
@@ -169,6 +169,7 @@ export class TableHelper {
         let bgcolor: any = '';
         let tooltip: any = '';
         let text_font_family: any = 'default';
+        let text_formatting: any = 'none';
 
         // Detect trailing options object from transpiler's named-args pattern
         // e.g. table.cell(t1, 0, 0, {text: "X", text_color: "#fff", ...})
@@ -193,6 +194,7 @@ export class TableHelper {
             bgcolor = posArgs[10] ?? opts.bgcolor ?? bgcolor;
             tooltip = posArgs[11] ?? opts.tooltip ?? tooltip;
             text_font_family = posArgs[12] ?? opts.text_font_family ?? text_font_family;
+            text_formatting = posArgs[13] ?? opts.text_formatting ?? text_formatting;
         } else {
             table_id = args[0];
             column = args[1] ?? 0;
@@ -207,6 +209,7 @@ export class TableHelper {
             bgcolor = args[10] ?? bgcolor;
             tooltip = args[11] ?? tooltip;
             text_font_family = args[12] ?? text_font_family;
+            text_formatting = args[13] ?? text_formatting;
         }
 
         const tbl = this._resolve(table_id) as TableObject;
@@ -226,6 +229,7 @@ export class TableHelper {
             bgcolor: this._resolve(bgcolor) || '',
             tooltip: this._resolveText(this._resolve(tooltip)),
             text_font_family: this._resolve(text_font_family) || 'default',
+            text_formatting: this._resolve(text_formatting) || 'none',
         });
     }
 
@@ -382,6 +386,11 @@ export class TableHelper {
     @silentInSecondary
     cell_set_text_font_family(table_id: any, column: any, row: any, text_font_family: any): void {
         this._setCellProp(table_id, column, row, 'text_font_family', text_font_family);
+    }
+
+    @silentInSecondary
+    cell_set_text_formatting(table_id: any, column: any, row: any, text_formatting: any): void {
+        this._setCellProp(table_id, column, row, 'text_formatting', text_formatting);
     }
 
     // ── Table setter methods ───────────────────────────────────

--- a/src/namespaces/table/TableObject.ts
+++ b/src/namespaces/table/TableObject.ts
@@ -28,6 +28,7 @@ export interface TableCell {
     bgcolor: string;
     tooltip: string;
     text_font_family: string;
+    text_formatting: string;
     _merged: boolean;
     _merge_parent: [number, number] | null; // [col, row] of the merge origin
 }
@@ -174,6 +175,7 @@ export class TableObject {
     cell_set_text_halign(...args: any[]) { return this._helper.cell_set_text_halign(this, ...args); }
     cell_set_text_valign(...args: any[]) { return this._helper.cell_set_text_valign(this, ...args); }
     cell_set_text_font_family(...args: any[]) { return this._helper.cell_set_text_font_family(this, ...args); }
+    cell_set_text_formatting(...args: any[]) { return this._helper.cell_set_text_formatting(this, ...args); }
 
     set_position(...args: any[]) { return this._helper.set_position(this, ...args); }
     set_bgcolor(...args: any[]) { return this._helper.set_bgcolor(this, ...args); }
@@ -194,6 +196,7 @@ export class TableObject {
             bgcolor: '',
             tooltip: '',
             text_font_family: 'default',
+            text_formatting: 'none',
             _merged: false,
             _merge_parent: null,
         };

--- a/tests/namespaces/table/table.test.ts
+++ b/tests/namespaces/table/table.test.ts
@@ -766,4 +766,48 @@ describe('TABLE Namespace', () => {
         expect(result.hasHelper[0]).toBe(true);
         expect(result.cellText[0]).toBe('Works');
     });
+
+    it('table.cell_set_text_formatting() and t.cell_set_text_formatting() update text formatting', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2025-01-01').getTime(), new Date('2025-11-20').getTime());
+
+        const { result } = await pineTS.run((context) => {
+            var t = table.new('top_right', 3, 2);
+            t.cell(0, 0, 'A');
+            t.cell(1, 0, 'B');
+            var defaultFormatting = t.getCell(0, 0).text_formatting;
+            table.cell_set_text_formatting(t, 0, 0, text.format_bold);
+            t.cell_set_text_formatting(1, 0, text.format_italic);
+            var cellA = t.getCell(0, 0).text_formatting;
+            var cellB = t.getCell(1, 0).text_formatting;
+            return { defaultFormatting, cellA, cellB };
+        });
+
+        expect(result.defaultFormatting[0]).toBe('none');
+        expect(result.cellA[0]).toBe('bold');
+        expect(result.cellB[0]).toBe('italic');
+    });
+
+    // Script compiles on TradingView (pine-facade translate_light).
+    it('native Pine: text_formatting in table.cell() and cell_set_text_formatting() reach plot data', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2025-01-01').getTime(), new Date('2025-01-10').getTime());
+
+        const { plots } = await pineTS.run(`
+//@version=6
+indicator("table text formatting", overlay = true)
+var t = table.new(position.top_right, 3, 1)
+if barstate.islast
+    table.cell(t, 0, 0, "a", text_formatting = text.format_bold)
+    table.cell(t, 1, 0, "b")
+    table.cell_set_text_formatting(t, 1, 0, text.format_italic)
+    table.cell(t, 2, 0, "c")
+    t.cell_set_text_formatting(2, 0, text.format_bold)
+plot(close)
+`);
+
+        const tbl = plots['__tables__'].data[0].value.find((t: any) => t.columns === 3);
+        const cells = tbl.cells[0];
+        expect(cells[0].text_formatting).toBe('bold');
+        expect(cells[1].text_formatting).toBe('italic');
+        expect(cells[2].text_formatting).toBe('bold');
+    });
 });


### PR DESCRIPTION
## Problem

`table.cell_set_text_formatting()` is not implemented or bound in `Context`, so scripts that call it fail. `table.cell()` also ignores the v6 `text_formatting` argument.

```pine
//@version=6
indicator("repro", overlay = true)
var t = table.new(position.top_right, 1, 1)
if barstate.islast
    table.cell(t, 0, 0, "x", text_formatting = text.format_bold)
    table.cell_set_text_formatting(t, 0, 0, text.format_italic)
plot(close)
```

→ `TypeError: table.cell_set_text_formatting is not a function`

This script compiles on TradingView. 1 of 729 popular open-source indicators failed on this (Parabolic SAR Constraint Kinematics & Run Geometry).

## Fix

This mirrors `cell_set_text_font_family`:

- `table.cell()` now reads `text_formatting`, both positionally (index 13) and as a named argument. It is stored on the cell with default `"none"`, matching `text.format_none`, and added to `TABLE_CELL_PARAMS`.
- Add `cell_set_text_formatting` to `TableHelper` and to the `TableObject` delegate, and bind it in `Context`.
- Update the API coverage docs (`table.md`, `pinescript-v6/table.json`).

## Tests

- `tests/namespaces/table/table.test.ts`: the namespace setter and the method delegate, plus a native Pine script covering `text_formatting` in `table.cell()`. The Pine script compiles on TradingView.
- The new tests fail on `dev` (`table.cell_set_text_formatting is not a function`) and pass with this change. `table-named-args.test.ts` still passes. Full suite: 1840 passed, 5 skipped, 16 todo.
- Real indicators: the affected indicator now runs without errors (60 labels, 1 table).
- Differential check: all 729 indicators were run on identical cached market data within the same clock hour, once against `dev` and once against this branch. The affected indicator now runs without errors. No regressions. The only changed output values are in 6 scripts that use `timenow` or `math.random`; their output also differs between two identical `dev` runs. Output was compared with the `text_formatting` key left out, because this change adds that key to every table cell.

The repro scripts and tooling are in https://github.com/lenstrats/pinets-compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
