### PR TITLE
feat: scan and override inputs on member-path assignments

### DIFF
--- a/src/Indicator/scanInputs.ts
+++ b/src/Indicator/scanInputs.ts
@@ -4,6 +4,7 @@
 import { pineToJS } from '../transpiler/pineToJS/pineToJS.index';
 import { resolveColorToRgba, rgbaToHex8 } from '../namespaces/color/PineColor';
 import { SOURCE_BUILTINS } from '../namespaces/input/utils';
+import { findInputCallInExpression, memberExpressionPath } from '../transpiler/utils/inputExpression';
 import type { IPineInput, PineInputType, PineInputDisplay } from './types';
 
 /**
@@ -167,79 +168,110 @@ function collectConstTable(ast: any): ConstTable {
  *   - `let len = input.int(14, "Len", ...)`  → VariableDeclaration → CallExpression
  *   - `len = input.int(...)` is reassignment — also a VariableDeclaration because
  *      Pine simple `=` lowers to `let` at the parser layer.
+ *   - `cfg.show := input.bool(...)`          → ExpressionStatement wrapping an
+ *      AssignmentExpression whose LHS is a member path. This is the settings /
+ *      config-object assignment style; the input is harvested under the member
+ *      path (`cfg.show`) as its varId.
+ *   - `width = input.int(1, ...) * 2` — the input call nested inside a pure
+ *      expression tree (Binary/Logical/Conditional/Unary); harvested under the
+ *      assigned variable name.
  *
  * Anything else returns null and is skipped.
  */
 function decodeInputCall(node: any, enumTable: EnumTable, constTable: ConstTable): IPineInput | null {
-    if (node.type !== 'VariableDeclaration') return null;
-    for (const decl of node.declarations ?? []) {
-        const init = decl?.init;
-        if (!init || init.type !== 'CallExpression') continue;
-
-        // Match input.<fn>(...) or bare input(...).
-        const callee = init.callee;
-        let fnName: string | null = null;
-        if (
-            callee?.type === 'MemberExpression' &&
-            callee.object?.type === 'Identifier' &&
-            callee.object.name === 'input' &&
-            callee.property?.type === 'Identifier'
-        ) {
-            fnName = callee.property.name;
-        } else if (callee?.type === 'Identifier' && callee.name === 'input') {
-            fnName = ''; // bare wrapper
+    if (node.type === 'VariableDeclaration') {
+        for (const decl of node.declarations ?? []) {
+            const meta = decodeInputAssignment(decl.id, decl?.init, enumTable, constTable);
+            if (meta) return meta;
         }
-        if (fnName === null) continue;
-        const isIntFloat = fnName === 'int' || fnName === 'float';
-        if (fnName !== '' && !isIntFloat && !(fnName in POSITIONAL_BY_FN)) continue;
-
-        // Split positionals from the trailing named-args ObjectExpression.
-        const args = init.arguments ?? [];
-        const lastArg = args[args.length - 1];
-        const hasNamed = lastArg?.type === 'ObjectExpression';
-        const positionals = hasNamed ? args.slice(0, -1) : args.slice();
-        const named: any[] = hasNamed ? (lastArg.properties ?? []) : [];
-
-        const raw: Record<string, any> = {};
-        if (fnName === 'int' || fnName === 'float') {
-            decodeIntFloatPositionals(positionals, named, raw);
-        } else {
-            decodePositionals(POSITIONAL_BY_FN[fnName], positionals, raw);
-        }
-        for (const p of named) {
-            if (p.type !== 'Property' || !p.key?.name) continue;
-            raw[p.key.name] = p.value;
-        }
-
-        // Now turn raw AST values into JS primitives, resolving enum + source refs.
-        const resolved: any = {};
-        for (const k of Object.keys(raw)) {
-            resolved[k] = resolveValue(raw[k], enumTable, constTable);
-        }
-
-        // Determine the type tag. For bare `input(...)`, infer from defval.
-        const type = fnName === '' ? inferAutoType(resolved.defval) : TYPE_BY_FN[fnName];
-        if (!type) continue;
-
-        const meta: IPineInput = { type, defval: resolved.defval };
-        // The assigned variable name — the primary override key. Only simple
-        // `name = input.*()` assignments carry one (Identifier id).
-        if (decl.id?.type === 'Identifier' && typeof decl.id.name === 'string') meta.varId = decl.id.name;
-        if (resolved.title !== undefined) meta.title = String(resolved.title);
-        if (resolved.tooltip !== undefined) meta.tooltip = String(resolved.tooltip);
-        if (resolved.group !== undefined) meta.group = String(resolved.group);
-        if (resolved.inline !== undefined) meta.inline = String(resolved.inline);
-        if (resolved.confirm !== undefined) meta.confirm = Boolean(resolved.confirm);
-        if (resolved.active !== undefined) meta.active = Boolean(resolved.active);
-        if (resolved.display !== undefined) meta.display = normalizeDisplay(resolved.display);
-        if (resolved.options !== undefined && Array.isArray(resolved.options)) meta.options = resolved.options;
-        if (typeof resolved.minval === 'number') meta.minval = resolved.minval;
-        if (typeof resolved.maxval === 'number') meta.maxval = resolved.maxval;
-        if (typeof resolved.step === 'number') meta.step = resolved.step;
-
-        return meta;
+        return null;
+    }
+    if (node.type === 'ExpressionStatement') {
+        const expr = node.expression;
+        if (!expr || expr.type !== 'AssignmentExpression' || expr.operator !== '=') return null;
+        const leftType = expr.left?.type;
+        if (leftType !== 'Identifier' && leftType !== 'MemberExpression') return null;
+        return decodeInputAssignment(expr.left, expr.right, enumTable, constTable);
     }
     return null;
+}
+
+/**
+ * Decode an input call assigned to `targetNode`, or return `null`.
+ *
+ * `initExpr` may BE the input call or a pure expression tree containing one
+ * (see findInputCallInExpression). The varId is `targetNode`'s Pine-level path
+ * (bare name for an Identifier, dotted chain for a MemberExpression) — this is
+ * also the key the transpiler injects as the runtime `{ __varId }` sentinel.
+ */
+function decodeInputAssignment(targetNode: any, initExpr: any, enumTable: EnumTable, constTable: ConstTable): IPineInput | null {
+    const init = findInputCallInExpression(initExpr);
+    if (!init) return null;
+
+    // Match input.<fn>(...) or bare input(...).
+    const callee = init.callee;
+    let fnName: string | null = null;
+    if (
+        callee?.type === 'MemberExpression' &&
+        callee.object?.type === 'Identifier' &&
+        callee.object.name === 'input' &&
+        callee.property?.type === 'Identifier'
+    ) {
+        fnName = callee.property.name;
+    } else if (callee?.type === 'Identifier' && callee.name === 'input') {
+        fnName = ''; // bare wrapper
+    }
+    if (fnName === null) return null;
+    const isIntFloat = fnName === 'int' || fnName === 'float';
+    if (fnName !== '' && !isIntFloat && !(fnName in POSITIONAL_BY_FN)) return null;
+
+    // Split positionals from the trailing named-args ObjectExpression.
+    const args = init.arguments ?? [];
+    const lastArg = args[args.length - 1];
+    const hasNamed = lastArg?.type === 'ObjectExpression';
+    const positionals = hasNamed ? args.slice(0, -1) : args.slice();
+    const named: any[] = hasNamed ? (lastArg.properties ?? []) : [];
+
+    const raw: Record<string, any> = {};
+    if (fnName === 'int' || fnName === 'float') {
+        decodeIntFloatPositionals(positionals, named, raw);
+    } else {
+        decodePositionals(POSITIONAL_BY_FN[fnName], positionals, raw);
+    }
+    for (const p of named) {
+        if (p.type !== 'Property' || !p.key?.name) continue;
+        raw[p.key.name] = p.value;
+    }
+
+    // Now turn raw AST values into JS primitives, resolving enum + source refs.
+    const resolved: any = {};
+    for (const k of Object.keys(raw)) {
+        resolved[k] = resolveValue(raw[k], enumTable, constTable);
+    }
+
+    // Determine the type tag. For bare `input(...)`, infer from defval.
+    const type = fnName === '' ? inferAutoType(resolved.defval) : TYPE_BY_FN[fnName];
+    if (!type) return null;
+
+    const meta: IPineInput = { type, defval: resolved.defval };
+    // The assigned target — the primary override key. Plain variable names come
+    // from Identifier ids; settings/config-object fields are dotted member
+    // paths (e.g. `htf1.settings.show`). Both match the runtime sentinel.
+    const varId = memberExpressionPath(targetNode);
+    if (varId !== undefined) meta.varId = varId;
+    if (resolved.title !== undefined) meta.title = String(resolved.title);
+    if (resolved.tooltip !== undefined) meta.tooltip = String(resolved.tooltip);
+    if (resolved.group !== undefined) meta.group = String(resolved.group);
+    if (resolved.inline !== undefined) meta.inline = String(resolved.inline);
+    if (resolved.confirm !== undefined) meta.confirm = Boolean(resolved.confirm);
+    if (resolved.active !== undefined) meta.active = Boolean(resolved.active);
+    if (resolved.display !== undefined) meta.display = normalizeDisplay(resolved.display);
+    if (resolved.options !== undefined && Array.isArray(resolved.options)) meta.options = resolved.options;
+    if (typeof resolved.minval === 'number') meta.minval = resolved.minval;
+    if (typeof resolved.maxval === 'number') meta.maxval = resolved.maxval;
+    if (typeof resolved.step === 'number') meta.step = resolved.step;
+
+    return meta;
 }
 
 /**

--- a/src/transpiler/transformers/StatementTransformer.ts
+++ b/src/transpiler/transformers/StatementTransformer.ts
@@ -5,6 +5,7 @@ import * as walk from 'acorn-walk';
 import ScopeManager from '../analysis/ScopeManager';
 import { ASTFactory, CONTEXT_NAME } from '../utils/ASTFactory';
 import { NAMESPACES_LIKE, FACTORY_METHODS } from '../settings';
+import { findInputCallInExpression, memberExpressionPath } from '../utils/inputExpression';
 import {
     transformIdentifier,
     transformCallExpression,
@@ -68,6 +69,18 @@ export function createLoopGuardNodes(guardName: string): { counterDecl: any; gua
 }
 
 export function transformAssignmentExpression(node: any, scopeManager: ScopeManager): void {
+    // Tag `cfg.show := input.*(…)` so the input call gets the `{ __varId }`
+    // sentinel — the runtime override key matching scanInputs' meta varId for
+    // the member path (e.g. `htf1.settings.show`). Must read the ORIGINAL LHS
+    // path before it's rewritten to `$.get(..., 0).show` below.
+    if (node.left && node.right) {
+        const memberLhsPath = memberExpressionPath(node.left);
+        if (memberLhsPath !== undefined) {
+            const inputCall = findInputCallInExpression(node.right);
+            if (inputCall) inputCall._varId = memberLhsPath;
+        }
+    }
+
     let targetVarRef = null;
     // Transform assignment expressions to use the context object
     if (node.left.type === 'Identifier') {
@@ -258,12 +271,13 @@ export function transformVariableDeclaration(varNode: any, scopeManager: ScopeMa
         // inject it as a `{ __varId }` sentinel on the input call. This is the
         // runtime handle that lets `.input[varId]` overrides target a specific
         // input even when titles are empty or duplicated.
-        if (decl.init?.type === 'CallExpression' && decl.id?.type === 'Identifier') {
-            const c = decl.init.callee;
-            const isInputCall =
-                (c?.type === 'MemberExpression' && c.object?.type === 'Identifier' && c.object.name === 'input') ||
-                (c?.type === 'Identifier' && c.name === 'input');
-            if (isInputCall) decl.init._varId = decl.id.name;
+        //
+        // The init may be the input call itself OR a pure expression tree
+        // wrapping one (`width = input.int(1) * 2`); findInputCallInExpression
+        // handles both — scanningInputs' meta varId covers the same shapes.
+        if (decl.init && decl.id?.type === 'Identifier') {
+            const inputCall = findInputCallInExpression(decl.init);
+            if (inputCall) inputCall._varId = decl.id.name;
         }
 
         // Rewrite NAMESPACES_LIKE entries (na, time, etc.) to .__value in variable initializers

--- a/src/transpiler/utils/inputExpression.ts
+++ b/src/transpiler/utils/inputExpression.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 LuxAlgo
+
+/**
+ * Shared AST helpers for `input.*` declarations on NON-variable targets —
+ * member-assignment (`cfg.show := input.bool(...)`) and expression-wrapped
+ * assignments (`width = input.int(1) * 2`).
+ *
+ * Both the input scanner (scanInputs) and the transpiler (StatementTransformer)
+ * need the same two facts:
+ *   1. Is this init expression an `input.*` call (possibly nested inside a
+ *      pure arithmetic / conditional tree)?  → the CallExpression itself.
+ *   2. What path was it assigned to, exactly as written in Pine (`Identifier`
+ *      or dotted `MemberExpression` chain)?  → the varId string.
+ *
+ * Keeping the two in lock-step guarantees the meta varId (what UIs expose /
+ * key overrides by) equals the runtime `{ __varId }` sentinel the transpiler
+ * injects (how the runtime resolves overrides).
+ */
+
+/** True when `callee` is `input.<fn>` or the bare `input` wrapper. */
+export function isInputCallee(callee: any): boolean {
+    if (!callee) return false;
+    if (
+        callee.type === 'MemberExpression' &&
+        callee.object?.type === 'Identifier' &&
+        callee.object.name === 'input' &&
+        callee.property?.type === 'Identifier'
+    ) {
+        return true;
+    }
+    return callee.type === 'Identifier' && callee.name === 'input';
+}
+
+/**
+ * Descend only through "pure" expression containers (arithmetic, logical,
+ * conditional, unary, grouping) to locate an `input.*` call. Stops at any
+ * other CallExpression — an input buried inside `ta.sma(input.int(1), 5)` is
+ * an argument to something else, not the assignment's own input declaration.
+ * Returns the first input call found, or null.
+ */
+export function findInputCallInExpression(expr: any): any | null {
+    if (!expr) return null;
+    if (expr.type === 'CallExpression') {
+        return isInputCallee(expr.callee) ? expr : null;
+    }
+    let children: any | any[] | undefined;
+    switch (expr.type) {
+        case 'BinaryExpression':
+        case 'LogicalExpression':
+            children = [expr.left, expr.right];
+            break;
+        case 'ConditionalExpression':
+            children = [expr.test, expr.consequent, expr.alternate];
+            break;
+        case 'UnaryExpression':
+        case 'AwaitExpression':
+        case 'ParenthesizedExpression':
+            children = expr.argument;
+            break;
+        default:
+            return null;
+    }
+    const iterate = Array.isArray(children) ? children : [children];
+    for (const child of iterate) {
+        if (!child) continue;
+        const found = findInputCallInExpression(child);
+        if (found) return found;
+    }
+    return null;
+}
+
+/**
+ * Flatten an assignment target into its Pine-level handle — `Identifier` name
+ * (`len`) or dotted member chain (`cfg.settings.show`). Returns undefined when
+ * the target isn't a plain named path (computed access, call results, ...).
+ */
+export function memberExpressionPath(node: any): string | undefined {
+    if (!node) return undefined;
+    if (node.type === 'Identifier' && typeof node.name === 'string') return node.name;
+    if (node.type === 'MemberExpression' && !node.computed) {
+        const obj = memberExpressionPath(node.object);
+        const prop = node.property?.type === 'Identifier' ? node.property.name : undefined;
+        if (obj !== undefined && prop !== undefined) return `${obj}.${prop}`;
+    }
+    return undefined;
+}

--- a/tests/core/indicator_inputs.test.ts
+++ b/tests/core/indicator_inputs.test.ts
@@ -222,6 +222,91 @@ plot(close)`);
     });
 });
 
+describe('Settings-object (member-assignment) inputs', () => {
+    const ind = (code: string) => new Indicator(code);
+
+    it('scans `s.show := input.bool(...)` under the dotted member path as varId', () => {
+        const metas = ind(`//@version=6
+indicator("T")
+type S
+    bool show
+    int  n
+var S s = S.new()
+s.show := input.bool(true,   "Show", inline = "grp", group = "Main")
+s.n    := input.int(7, "N", inline = "grp", group = "Main")
+plot(close)`).getInputsMeta();
+        expect(metas).toHaveLength(2);
+        expect(metas[0]).toMatchObject({ varId: 's.show', type: 'bool', title: 'Show', defval: true, inline: 'grp', group: 'Main' });
+        expect(metas[1]).toMatchObject({ varId: 's.n', type: 'int', title: 'N', defval: 7, inline: 'grp' });
+    });
+
+    it('harvests an input nested in an expression on a member path', () => {
+        const metas = ind(`//@version=6
+indicator("T")
+type S
+    int w
+var S s = S.new()
+s.w := input.int(1, "Width") * 2
+plot(close)`).getInputsMeta();
+        expect(metas).toHaveLength(1);
+        expect(metas[0]).toMatchObject({ varId: 's.w', type: 'int', title: 'Width', defval: 1 });
+    });
+
+    it('harvests a plain-variable init wrapped in an expression', () => {
+        const metas = ind(`//@version=6
+indicator("T")
+width = input.int(1, "W", inline = "x") * 2
+plot(close)`).getInputsMeta();
+        expect(metas).toHaveLength(1);
+        expect(metas[0]).toMatchObject({ varId: 'width', type: 'int', title: 'W', defval: 1, inline: 'x' });
+    });
+
+    it('overrides a member-path input by its dotted varId', () => {
+        const i = ind(`//@version=6
+indicator("T")
+type S
+    bool show
+    int  n
+var S s = S.new()
+s.show := input.bool(true, "Show")
+s.n    := input.int(7, "N")
+plot(close)`);
+        i.input['s.show'] = false;
+        i.input['s.n'] = 21;
+        const rt = i.getRuntimeInputs();
+        expect(rt['s.show']).toBe(false);
+        expect(rt['s.n']).toBe(21);
+    });
+
+    it('resolves a member-path override at runtime (sentinel matches scanner varId)', async () => {
+        const code = `//@version=6
+indicator("T")
+type S
+    bool show
+    int  n
+var S s = S.new()
+s.show := input.bool(true,  "Show")
+s.n    := input.int(7, "N")
+v = s.show ? s.n : 0
+plot(v, "v")`;
+
+        const def = new Indicator(code);
+        const defaultCtx = await new PineTS(Provider.Mock, 'BTCUSDC', '1h').run(def);
+        expect(defaultCtx.plots['v'].data[0].value).toBe(7);
+
+        const off = new Indicator(code);
+        off.input['s.show'] = false;
+        const offCtx = await new PineTS(Provider.Mock, 'BTCUSDC', '1h').run(off);
+        expect(offCtx.plots['v'].data[0].value).toBe(0);
+
+        const n = new Indicator(code);
+        n.input['s.show'] = true;
+        n.input['s.n'] = 21;
+        const nCtx = await new PineTS(Provider.Mock, 'BTCUSDC', '1h').run(n);
+        expect(nCtx.plots['v'].data[0].value).toBe(21);
+    });
+});
+
 import { normalizeColorToRgbaHex } from '../../src/namespaces/color/PineColor';
 
 describe('Color input defval normalization (getInputsMeta)', () => {


### PR DESCRIPTION
- scanInputs now harvests input.*() calls from ExpressionStatement / AssignmentExpression (Identifier or MemberExpression LHS), exposing settings-object style declarations with a dotted-path varId (e.g. htf1.settings.show).

- StatementTransformer tags the runtime { __varId } sentinel for direct member assignments and expression-wrapped input calls (width = input.int(1) * 2), matching the scan meta varId so .input[varId] overrides resolve at runtime.

- Added shared helpers (inputExpression.ts) so scanner and transformer agree on which AST forms contain an input call.